### PR TITLE
controller: Change Volume.Spec.Size from string to int64

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/longhorn-manager/engineapi"
 	"github.com/rancher/longhorn-manager/manager"
 	"github.com/rancher/longhorn-manager/types"
-	"github.com/rancher/longhorn-manager/util"
 
 	longhorn "github.com/rancher/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
 )
@@ -302,11 +301,6 @@ func toVolumeResource(v *longhorn.Volume, ve *longhorn.Engine, vrs map[string]*l
 		}}
 	}
 
-	size, err := util.ConvertSize(v.Spec.Size)
-	if err != nil {
-		logrus.Error("BUG: invalid size %v for volume %v", v.Spec.Size, v.Name)
-	}
-
 	state := string(v.Status.State)
 	if v.Status.State == types.VolumeStateAttached ||
 		(v.Status.State == types.VolumeStateDetached &&
@@ -321,7 +315,7 @@ func toVolumeResource(v *longhorn.Volume, ve *longhorn.Engine, vrs map[string]*l
 			Links:   map[string]string{},
 		},
 		Name:                v.Name,
-		Size:                strconv.FormatInt(size, 10),
+		Size:                strconv.FormatInt(v.Spec.Size, 10),
 		FromBackup:          v.Spec.FromBackup,
 		NumberOfReplicas:    v.Spec.NumberOfReplicas,
 		State:               state,

--- a/api/volume.go
+++ b/api/volume.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -9,6 +10,7 @@ import (
 	"github.com/rancher/go-rancher/client"
 
 	"github.com/rancher/longhorn-manager/types"
+	"github.com/rancher/longhorn-manager/util"
 
 	longhorn "github.com/rancher/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
 )
@@ -92,8 +94,12 @@ func (s *Server) VolumeCreate(rw http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 
+	size, err := util.ConvertSize(volume.Size)
+	if err != nil {
+		return fmt.Errorf("fail to parse size %v", err)
+	}
 	v, err := s.m.Create(volume.Name, &types.VolumeSpec{
-		Size:                volume.Size,
+		Size:                size,
 		FromBackup:          volume.FromBackup,
 		NumberOfReplicas:    volume.NumberOfReplicas,
 		StaleReplicaTimeout: volume.StaleReplicaTimeout,

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -34,7 +34,7 @@ const (
 	TestPodName      = "test-pod-name"
 
 	TestVolumeName         = "test-volume"
-	TestVolumeSize         = "1g"
+	TestVolumeSize         = 1073741824
 	TestVolumeStaleTimeout = 60
 
 	TestTimeNow = "2015-01-02T00:00:00Z"

--- a/types/resource.go
+++ b/types/resource.go
@@ -21,7 +21,7 @@ const (
 
 type VolumeSpec struct {
 	OwnerID             string         `json:"ownerID"`
-	Size                string         `json:"size"`
+	Size                int64          `json:"size,string"`
 	FromBackup          string         `json:"fromBackup"`
 	NumberOfReplicas    int            `json:"numberOfReplicas"`
 	StaleReplicaTimeout int            `json:"staleReplicaTimeout"`
@@ -86,7 +86,7 @@ type EngineStatus struct {
 
 type ReplicaSpec struct {
 	InstanceSpec
-	VolumeSize  string `json:"volumeSize"`
+	VolumeSize  int64  `json:"volumeSize,string"`
 	RestoreFrom string `json:"restoreFrom"`
 	RestoreName string `json:"restoreName"`
 	HealthyAt   string `json:"healthyAt"`

--- a/util/util.go
+++ b/util/util.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -73,11 +73,11 @@ func ConvertSize(size interface{}) (int64, error) {
 		if size == "" {
 			return 0, nil
 		}
-		sizeInBytes, err := units.RAMInBytes(size)
+		quantity, err := resource.ParseQuantity(size)
 		if err != nil {
 			return 0, errors.Wrapf(err, "error parsing size '%s'", size)
 		}
-		return sizeInBytes, nil
+		return quantity.Value(), nil
 	}
 	return 0, errors.Errorf("could not parse size '%v'", size)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -8,17 +8,33 @@ import (
 func TestConvertSize(t *testing.T) {
 	assert := require.New(t)
 
-	size, err := ConvertSize("0b")
+	size, err := ConvertSize("0m")
 	assert.Nil(err)
 	assert.Equal(int64(0), size)
 
-	size, err = ConvertSize("1024b")
+	size, err = ConvertSize("0Mi")
 	assert.Nil(err)
-	assert.Equal(int64(1024), size)
+	assert.Equal(int64(0), size)
+
+	size, err = ConvertSize("1024k")
+	assert.Nil(err)
+	assert.Equal(int64(1024*1000), size)
+
+	size, err = ConvertSize("1024Ki")
+	assert.Nil(err)
+	assert.Equal(int64(1024*1024), size)
 
 	size, err = ConvertSize("1024")
 	assert.Nil(err)
 	assert.Equal(int64(1024), size)
+
+	size, err = ConvertSize("1Gi")
+	assert.Nil(err)
+	assert.Equal(int64(1024*1024*1024), size)
+
+	size, err = ConvertSize("1G")
+	assert.Nil(err)
+	assert.Equal(int64(1E9), size)
 }
 
 func TestRoundUpSize(t *testing.T) {


### PR DESCRIPTION
The interpretation of different units can be vary. So keep it consistent by
passing bytes in int64 which won't be up to interpretation.

Also start to use Kubernetes' `Ki`(1024) vs `k`(1000) as standard units.