### PR TITLE
Enable S3 backup

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -308,6 +308,7 @@ func toSettingCollection(settings *types.SettingsInfo) *client.GenericCollection
 	data := []interface{}{
 		toSettingResource(types.SettingBackupTarget, settings.BackupTarget),
 		toSettingResource(types.SettingDefaultEngineImage, settings.DefaultEngineImage),
+		toSettingResource(types.SettingBackupTargetCredentialSecret, settings.BackupTargetCredentialSecret),
 	}
 	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "setting"}}
 }

--- a/api/setting.go
+++ b/api/setting.go
@@ -35,6 +35,8 @@ func (s *Server) SettingsGet(w http.ResponseWriter, req *http.Request) error {
 		value = si.BackupTarget
 	case types.SettingDefaultEngineImage:
 		value = si.DefaultEngineImage
+	case types.SettingBackupTargetCredentialSecret:
+		value = si.BackupTargetCredentialSecret
 	default:
 		return errors.Errorf("invalid setting name %v", name)
 	}
@@ -62,6 +64,8 @@ func (s *Server) SettingsSet(w http.ResponseWriter, req *http.Request) error {
 		si.BackupTarget = setting.Value
 	case types.SettingDefaultEngineImage:
 		si.DefaultEngineImage = setting.Value
+	case types.SettingBackupTargetCredentialSecret:
+		si.BackupTargetCredentialSecret = setting.Value
 	default:
 		return errors.Wrapf(err, "invalid setting name %v", name)
 	}

--- a/app/volume.go
+++ b/app/volume.go
@@ -242,10 +242,11 @@ func (job *Job) backupAndCleanup() error {
 	if err := job.snapshotAndCleanup(); err != nil {
 		return err
 	}
-	if err := job.engine.SnapshotBackup(job.snapshotName, job.backupTarget, job.labels); err != nil {
+	// CronJob template has covered the credential already, so we don't need to get the credential secret.
+	if err := job.engine.SnapshotBackup(job.snapshotName, job.backupTarget, job.labels, nil); err != nil {
 		return err
 	}
-	target := engineapi.NewBackupTarget(job.backupTarget, job.engineImage)
+	target := engineapi.NewBackupTarget(job.backupTarget, job.engineImage, nil)
 	backups, err := target.List(job.volumeName)
 	if err != nil {
 		return err

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -50,6 +50,19 @@ func (s *DataStore) GetSetting() (*longhorn.Setting, error) {
 	return result, err
 }
 
+func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]string, error) {
+	secret, err := s.kubeClient.CoreV1().Secrets(s.namespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	credentialSecret := make(map[string]string)
+	if secret.Data != nil {
+		credentialSecret[types.AWSAccessKey] = string(secret.Data[types.AWSAccessKey])
+		credentialSecret[types.AWSSecretKey] = string(secret.Data[types.AWSSecretKey])
+	}
+	return credentialSecret, nil
+}
+
 func getVolumeLabels(volumeName string) map[string]string {
 	return map[string]string{
 		longhornVolumeKey: volumeName,

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -59,6 +59,7 @@ func (s *DataStore) GetCredentialFromSecret(secretName string) (map[string]strin
 	if secret.Data != nil {
 		credentialSecret[types.AWSAccessKey] = string(secret.Data[types.AWSAccessKey])
 		credentialSecret[types.AWSSecretKey] = string(secret.Data[types.AWSSecretKey])
+		credentialSecret[types.AWSEndPoint] = string(secret.Data[types.AWSEndPoint])
 	}
 	return credentialSecret, nil
 }

--- a/deploy/01-prerequisite/02-serviceaccount.yaml
+++ b/deploy/01-prerequisite/02-serviceaccount.yaml
@@ -16,7 +16,7 @@ rules:
   verbs:
   - "*"
 - apiGroups: [""]
-  resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims", "nodes", "proxy/nodes", "pods/log"]
+  resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims", "nodes", "proxy/nodes", "pods/log", "secrets"]
   verbs: ["*"]
 - apiGroups: ["apps"]
   resources: ["daemonsets"]

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -15,8 +15,9 @@ import (
 )
 
 type BackupTarget struct {
-	URL   string
-	Image string
+	URL        string
+	Image      string
+	Credential map[string]string
 }
 
 type backupVolume struct {
@@ -28,10 +29,11 @@ type backupVolume struct {
 	Backups        map[string]interface{}
 }
 
-func NewBackupTarget(backupTarget, engineImage string) *BackupTarget {
+func NewBackupTarget(backupTarget, engineImage string, credential map[string]string) *BackupTarget {
 	return &BackupTarget{
-		URL:   backupTarget,
-		Image: engineImage,
+		URL:        backupTarget,
+		Image:      engineImage,
+		Credential: credential,
 	}
 }
 
@@ -40,6 +42,10 @@ func (b *BackupTarget) LonghornEngineBinary() string {
 }
 
 func (b *BackupTarget) ExecuteEngineBinary(args ...string) (string, error) {
+	err := util.ConfigBackupCredential(b.URL, b.Credential)
+	if err != nil {
+		return "", err
+	}
 	return util.Execute(b.LonghornEngineBinary(), args...)
 }
 

--- a/engineapi/enginesim.go
+++ b/engineapi/enginesim.go
@@ -181,7 +181,7 @@ func (e *EngineSimulator) SnapshotPurge() error {
 	return fmt.Errorf("Not implemented")
 }
 
-func (e *EngineSimulator) SnapshotBackup(snapName, backupTarget string, labels map[string]string) error {
+func (e *EngineSimulator) SnapshotBackup(snapName, backupTarget string, labels map[string]string, credential map[string]string) error {
 	return fmt.Errorf("Not implemented")
 }
 

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/rancher/longhorn-manager/util"
 )
 
 const (
@@ -72,7 +73,7 @@ func (e *Engine) SnapshotPurge() error {
 	return nil
 }
 
-func (e *Engine) SnapshotBackup(snapName, backupTarget string, labels map[string]string) error {
+func (e *Engine) SnapshotBackup(snapName, backupTarget string, labels map[string]string, credential map[string]string) error {
 	snap, err := e.SnapshotGet(snapName)
 	if err != nil {
 		return errors.Wrapf(err, "error getting snapshot '%s', volume '%s'", snapName, e.name)
@@ -85,6 +86,11 @@ func (e *Engine) SnapshotBackup(snapName, backupTarget string, labels map[string
 		args = append(args, "--label", k+"="+v)
 	}
 	args = append(args, snapName)
+	// set credential if backup for s3
+	err = util.ConfigBackupCredential(backupTarget, credential)
+	if err != nil {
+		return err
+	}
 	backup, err := e.ExecuteEngineBinaryWithTimeout(backupTimeout, args...)
 	if err != nil {
 		return err

--- a/engineapi/snapshot.go
+++ b/engineapi/snapshot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+
 	"github.com/rancher/longhorn-manager/util"
 )
 

--- a/engineapi/types.go
+++ b/engineapi/types.go
@@ -39,7 +39,7 @@ type EngineClient interface {
 	SnapshotDelete(name string) error
 	SnapshotRevert(name string) error
 	SnapshotPurge() error
-	SnapshotBackup(snapName, backupTarget string, labels map[string]string) error
+	SnapshotBackup(snapName, backupTarget string, labels map[string]string, credential map[string]string) error
 }
 
 type EngineClientRequest struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -104,14 +104,16 @@ type ReplicaStatus struct {
 }
 
 const (
-	SettingBackupTarget       = "backupTarget"
-	SettingDefaultEngineImage = "defaultEngineImage"
-	SettingEngineUpgradeImage = "engineUpgradeImage"
+	SettingBackupTarget                 = "backupTarget"
+	SettingDefaultEngineImage           = "defaultEngineImage"
+	SettingEngineUpgradeImage           = "engineUpgradeImage"
+	SettingBackupTargetCredentialSecret = "backupTargetCredentialSecret"
 )
 
 type SettingsInfo struct {
-	BackupTarget       string `json:"backupTarget"`
-	DefaultEngineImage string `json:"defaultEngineImage"`
+	BackupTarget                 string `json:"backupTarget"`
+	DefaultEngineImage           string `json:"defaultEngineImage"`
+	BackupTargetCredentialSecret string `json:"backupTargetCredentialSecret"`
 }
 
 type EngineImageState string

--- a/types/types.go
+++ b/types/types.go
@@ -30,6 +30,7 @@ const (
 
 	AWSAccessKey = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
+	AWSEndPoint  = "AWS_ENDPOINTS"
 
 	OptionFromBackup          = "fromBackup"
 	OptionNumberOfReplica     = "numberOfReplicas"

--- a/types/types.go
+++ b/types/types.go
@@ -28,6 +28,9 @@ const (
 	EnvPodNamespace = "POD_NAMESPACE"
 	EnvPodIP        = "POD_IP"
 
+	AWSAccessKey = "AWS_ACCESS_KEY_ID"
+	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
+
 	OptionFromBackup          = "fromBackup"
 	OptionNumberOfReplica     = "numberOfReplicas"
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"

--- a/util/util.go
+++ b/util/util.go
@@ -28,9 +28,10 @@ const (
 	ControllerServiceName = "controller"
 	ReplicaServiceName    = "replica"
 
+	BackupStoreTypeS3 = "s3"
 	AWSAccessKey      = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey      = "AWS_SECRET_ACCESS_KEY"
-	BackupStoreTypeS3 = "s3"
+	AWSEndPoint       = "AWS_ENDPOINTS"
 )
 
 var (
@@ -331,6 +332,7 @@ func ConfigBackupCredential(backupTarget string, credential map[string]string) e
 		if credential != nil && credential[AWSAccessKey] != "" && credential[AWSSecretKey] != "" {
 			os.Setenv(AWSAccessKey, credential[AWSAccessKey])
 			os.Setenv(AWSSecretKey, credential[AWSSecretKey])
+			os.Setenv(AWSEndPoint, credential[AWSEndPoint])
 		} else if os.Getenv(AWSAccessKey) == "" || os.Getenv(AWSSecretKey) == "" {
 			return fmt.Errorf("Could not backup for %s without credential secret", backupType)
 		}
@@ -368,6 +370,18 @@ func ConfigEnvWithCredential(backupTarget string, credentialSecret string, conta
 			},
 		}
 		container.Env = append(container.Env, secreKeyEnv)
+		endpointEnv := v1.EnvVar{
+			Name: AWSEndPoint,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: credentialSecret,
+					},
+					Key: AWSEndPoint,
+				},
+			},
+		}
+		container.Env = append(container.Env, endpointEnv)
 	}
 	return nil
 }


### PR DESCRIPTION
To support S3 backup for longhorn-manager, some components need aws credential.
- User need to create credential secret manually, and set secret name to `Setting.secretConfig`
- If backupTarget for s3, longhorn-manager need to get credential and passing them as an environment variable to engine.