### PR TITLE
Update Longhorn engine image

### DIFF
--- a/deploy/02-components/01-manager.yaml
+++ b/deploy/02-components/01-manager.yaml
@@ -25,7 +25,7 @@ spec:
         - -d
         - daemon
         - --engine-image
-        - rancher/longhorn-engine:9fd4ddd
+        - rancher/longhorn-engine:0f24789
         - --manager-image
         - rancher/longhorn-manager:1519bae
         - --service-account


### PR DESCRIPTION
Previous engine image 9fd4ddd is broken.

Update engine to: rancher/longhorn-engine:0f24789
Based on: 0f24789f066a2979cda9a9a5ba277860790d2a1f