### PR TITLE
driver: Output the result of mkfs to the log

### DIFF
--- a/driver/longhorn
+++ b/driver/longhorn
@@ -230,8 +230,9 @@ formatDevIfNeed() {
             echo -ne "Success"
         fi
     else
-        if ! OUT=$(mkfs -t ${newFsType} ${fullDevName} >/dev/null 2>&1); then
-            echo -ne "Failed to create fs ${newFsType} on device ${fullDevName}"
+        OUT=$(mkfs -t ${newFsType} ${fullDevName} 2>&1)
+        if [ $? -ne 0 ]; then
+            echo -ne "Failed to create fs ${newFsType} on device ${fullDevName} error message ${OUT}"
         else
             debug "format fs ${fullDevName} ${newFsType} successfully"
             echo -ne "Success"


### PR DESCRIPTION
issue: https://github.com/rancher/longhorn/issues/71

1. Catch result of `mkfs` execute
2. Embed the result in json of driver return 

## Test

### Kubelet log

rke deploy, use `docker logs kubelet 2>&1` to show the log, other use `journal -u kubelet`.

```
I0608 08:44:51.149196    6873 kubelet.go:1872] SyncLoop (DELETE, "api"): "voll-1-r-84920ccf_longhorn-system(13ef89a8-6af8-11e8-9c36-0644e7ac27f2)"
I0608 08:44:51.152964    6873 kubelet.go:1866] SyncLoop (REMOVE, "api"): "voll-1-r-84920ccf_longhorn-system(13ef89a8-6af8-11e8-9c36-0644e7ac27f2)"
I0608 08:44:51.153067    6873 kubelet.go:2060] Failed to delete pod "voll-1-r-84920ccf_longhorn-system(13ef89a8-6af8-11e8-9c36-0644e7ac27f2)", err: pod not found
E0608 08:44:56.913922    6873 driver-call.go:258] mount command failed, status: Failure, reason: Failed to create fs ext4 on device /dev/longhorn/voll-1 error message mkfs.ext2: invalid option -- 'x' Usage: mkfs.ext2 [-c|-l filename] [-b block-size] [-C cluster-size] [-i bytes-per-inode] [-I inode-size] [-J journal-options] [-G flex-group-size] [-N number-of-inodes] [-d root-directory] [-m reserved-blocks-percentage] [-o creator-os] [-g blocks-per-group] [-L volume-label] [-M last-mounted-directory] [-O feature[,...]] [-r fs-revision] [-E extended-option[,...]] [-t fs-type] [-T usage-type ] [-U UUID] [-e errors_behavior][-z undo_file] [-jnqvDFSV] device [blocks-count]
W0608 08:44:56.913948    6873 driver-call.go:144] FlexVolume: driver call failed: executable: /var/lib/kubelet/volumeplugins/rancher.io~longhorn/longhorn, args: [mount /var/lib/kubelet/pods/5f7eebe2-6af7-11e8-9c36-0644e7ac27f2/volumes/rancher.io~longhorn/voll-1 {"fromBackup":"","kubernetes.io/fsType":"ext4","kubernetes.io/pod.name":"volume-test-1","kubernetes.io/pod.namespace":"default","kubernetes.io/pod.uid":"5f7eebe2-6af7-11e8-9c36-0644e7ac27f2","kubernetes.io/pvOrVolumeName":"voll-1","kubernetes.io/readwrite":"rw","kubernetes.io/serviceAccount.name":"default","numberOfReplicas":"3","size":"2Gi","staleReplicaTimeout":"20"}],error: exit status 1, output: "{\"status\": \"Failure\", \"message\": \"Failed to create fs ext4 on device /dev/longhorn/voll-1 error message mkfs.ext2: invalid option -- 'x' Usage: mkfs.ext2 [-c|-l filename] [-b block-size] [-C cluster-size] [-i bytes-per-inode] [-I inode-size] [-J journal-options] [-G flex-group-size] [-N number-of-inodes] [-d root-directory] [-m reserved-blocks-percentage] [-o creator-os] [-g blocks-per-group] [-L volume-label] [-M last-mounted-directory] [-O feature[,...]] [-r fs-revision] [-Eextended-option[,...]] [-t fs-type] [-T usage-type ] [-U UUID] [-e errors_behavior][-z undo_file] [-jnqvDFSV] device [blocks-count]\"}"
E0608 08:44:56.914123    6873 nestedpendingoperations.go:267] Operation for "\"flexvolume-rancher.io/longhorn/5f7eebe2-6af7-11e8-9c36-0644e7ac27f2-voll-1\" (\"5f7eebe2-6af7-11e8-9c36-0644e7ac27f2\")" failed. No retries permitted until 2018-06-08 08:45:04.914083729 +0000 UTC m=+180825.111072135 (durationBeforeRetry 8s). Error: "MountVolume.SetUp failed for volume \"voll-1\" (UniqueName: \"flexvolume-rancher.io/longhorn/5f7eebe2-6af7-11e8-9c36-0644e7ac27f2-voll-1\") pod \"volume-test-1\" (UID: \"5f7eebe2-6af7-11e8-9c36-0644e7ac27f2\") : mount command failed, status: Failure, reason: Failed to create fs ext4 on device /dev/longhorn/voll-1 error message mkfs.ext2: invalid option -- 'x' Usage: mkfs.ext2 [-c|-l filename] [-b block-size] [-C cluster-size] [-i bytes-per-inode] [-I inode-size] [-J journal-options] [-G flex-group-size] [-N number-of-inodes] [-d root-directory] [-m reserved-blocks-percentage] [-o creator-os] [-g blocks-per-group] [-L volume-label] [-M last-mounted-directory] [-O feature[,...]] [-r fs-revision] [-E extended-option[,...]] [-t fs-type] [-T usage-type ] [-U UUID] [-e errors_behavior][-z undo_file] [-jnqvDFSV] device [blocks-count]"
I0608 08:45:04.994525    6873 reconciler.go:252] operationExecutor.MountVolume started for volume "voll-1" (UniqueName: "flexvolume-rancher.io/longhorn/5f7eebe2-6af7-11e8-9c36-0644e7ac27f2-voll-1") pod "volume-test-1" (UID: "5f7eebe2-6af7-11e8-9c36-0644e7ac27f2")
I0608 08:45:17.201674    6873 kubelet.go:1856] SyncLoop (ADD, "api"): "voll-1-r-84920ccf_longhorn-system(44b33622-6af8-11e8-9c36-0644e7ac27f2)"
```

### longhorn_driver log

`cat /var/log/longhorn_driver.log`

```
06/08/18 08:38:52 mount -------begin-------------
06/08/18 08:38:52 volume name: voll-1
06/08/18 08:38:52 json param: {"fromBackup":"","kubernetes.io/fsType":"ext4","kubernetes.io/pod.name":"volume-test-1","kubernetes.io/pod.namespace":"default","kubernetes.io/pod.uid":"5f7eebe2-6af7-11e8-9c36-0644e7ac27f2","kubernetes.io/pvOrVolumeName":"voll-1","kubernetes.io/readwrite":"rw","kubernetes.io/serviceAcco}       ":"default","numberOfReplicas":"3","size":"2Gi","staleReplicaTimeout":"20"--More--
06/08/18 08:38:52 mount path: /var/lib/kubelet/pods/5f7eebe2-6af7-11e8-9c36-0644e7ac27f2/volumes/rancher.io~longhorn/voll-1
06/08/18 08:38:52 acquire existed volume info:
06/08/18 08:38:52 getExistingVolume returns voll-1 exists but not in a valid state to attach
06/08/18 08:38:52 create volume response from http://10.43.87.202:9500/v1/volumes: {"actions":{},"controller":null,"created":"2018-06-08 08:38:52 +0000 UTC","endpoint":"","engineImage":"","fromBackup":"","id":"voll-1","links":{"self":"http://10.43.87.202:9500/v1/volumes/voll-1"},"name":"voll-1","numberOfReplicas":3,"recurringJobs":null,"replicas":[],"size":"2147483648","staleReplicaTimeout":20,"state":"","type":"volume"}
06/08/18 08:38:56 attach volume: {"actions":{"attach":"http://10.43.87.202:9500/v1/volumes/voll-1?action=attach","recurringUpdate":"http://10.43.87.202:9500/v1/volumes/voll-1?action=recurringUpdate","replicaRemove":"http://10.43.87.202:9500/v1/volumes/voll-1?action=replicaRemove"},"controller":null,"created":"2018-06-08 08:38:52 +0000 UTC","endpoint":"","engineImage":"","fromBackup":"","id":"voll-1","links":{"self":"http://10.43.87.202:9500/v1/volumes/voll-1"},"name":"voll-1","numberOfReplicas":3,"recurringJobs":null,"replicas":[],"size":"2147483648","staleReplicaTimeout":20,"state":"detached","type":"volume"}/v1/volumes/voll-1?action=replicaRemove","snapshotBackup":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotBackup","snapshotCreate":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotCreate","snapshotDelete":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotDelete","snapshotGet":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotGet","snapshotList":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotList","snapshotPurge":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotPurge","snapshotRevert":"http://10.43.87.202:9500/v1/volumes/voll-1?action=snapshotRevert"},"controller":null,"created":"2018-06-08 08:38:52 +0000 UTC","endpoint":"/dev/longhorn/voll-1","engineImage":"","fromBackup":"","id":"voll-1","links":{"self":"http://10.43.87.202:9500/v1/volumes/voll-1"},"name":"voll-1","numberOfReplicas":3,"recurringJobs":null,"replicas":[],"size":"2147483648","staleReplicaTimeout":20,"state":"healthy","type":"volume"}
06/08/18 08:39:52 {"status": "Failure", "message": "Failed to create fs ext4 on device /dev/longhorn/voll-1 error message mkfs.ext2: invalid option -- 'x' Usage: mkfs.ext2 [-c|-l filename] [-b block-size] [-C cluster-size] [-i bytes-per-inode] [-I inode-size] [-J journal-options] [-G flex-group-size] [-N number-of-inodes] [-d root-directory] [-m reserved-blocks-percentage] [-o creator-os] [-g blocks-per-group] [-L volume-label] [-M last-mounted-directory] [-O feature[,...]] [-r fs-revision] [-E extended-option[,...]] [-t fs-type] [-T usage-type ] [-U UUID] [-e errors_behavior][-z undo_file] [-jnqvDFSV] device [blocks-count]"}
```