### PR TITLE
Multiple disk with capacity based scheduling

### DIFF
--- a/api/forwarder.go
+++ b/api/forwarder.go
@@ -27,6 +27,13 @@ func OwnerIDFromVolume(m *manager.VolumeManager) func(req *http.Request) (string
 	}
 }
 
+func OwnerIDFromNode(m *manager.VolumeManager) func(req *http.Request) (string, error) {
+	return func(req *http.Request) (string, error) {
+		id := mux.Vars(req)["name"]
+		return id, nil
+	}
+}
+
 type NodeLocator interface {
 	GetCurrentNodeID() string
 	Node2APIAddress(nodeID string) (string, error)

--- a/api/model.go
+++ b/api/model.go
@@ -67,6 +67,8 @@ type Instance struct {
 	Running      bool   `json:"running"`
 	EngineImage  string `json:"engineImage"`
 	CurrentImage string `json:"currentImage"`
+	DiskID       string `json:"diskID"`
+	DataPath     string `json:"dataPath"`
 }
 
 type Controller struct {
@@ -376,6 +378,8 @@ func toVolumeResource(v *longhorn.Volume, ve *longhorn.Engine, vrs []*longhorn.R
 				NodeID:       r.Spec.NodeID,
 				EngineImage:  r.Spec.EngineImage,
 				CurrentImage: r.Status.CurrentImage,
+				DiskID:       r.Spec.DiskID,
+				DataPath:     r.Spec.DataPath,
 			},
 			Mode:     mode,
 			FailedAt: r.Spec.FailedAt,

--- a/api/node.go
+++ b/api/node.go
@@ -1,12 +1,17 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
+
+	"github.com/rancher/longhorn-manager/types"
+	"github.com/rancher/longhorn-manager/util"
 )
 
 func (s *Server) NodeList(rw http.ResponseWriter, req *http.Request) error {
@@ -29,12 +34,12 @@ func (s *Server) nodeList(apiContext *api.ApiContext) (*client.GenericCollection
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to get node ip")
 	}
-	return toNodeCollection(nodeList, nodeIPMap), nil
+	return toNodeCollection(nodeList, nodeIPMap, apiContext), nil
 }
 
 func (s *Server) NodeGet(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
-	id := mux.Vars(req)["id"]
+	id := mux.Vars(req)["name"]
 
 	node, err := s.m.GetNode(id)
 	if err != nil {
@@ -44,7 +49,7 @@ func (s *Server) NodeGet(rw http.ResponseWriter, req *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "fail to get node ip")
 	}
-	apiContext.Write(toNodeResource(node, nodeIPMap[node.Name]))
+	apiContext.Write(toNodeResource(node, nodeIPMap[node.Name], apiContext))
 	return nil
 }
 
@@ -55,7 +60,7 @@ func (s *Server) NodeUpdate(rw http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 
-	id := mux.Vars(req)["id"]
+	id := mux.Vars(req)["name"]
 	node, err := s.m.GetNode(id)
 	if err != nil {
 		return errors.Wrap(err, "fail to get node")
@@ -68,6 +73,71 @@ func (s *Server) NodeUpdate(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	unode, err := s.m.UpdateNode(node)
-	apiContext.Write(toNodeResource(unode, nodeIPMap[node.Name]))
+	if err != nil {
+		return err
+	}
+	apiContext.Write(toNodeResource(unode, nodeIPMap[node.Name], apiContext))
+	return nil
+}
+
+func (s *Server) DiskUpdate(rw http.ResponseWriter, req *http.Request) error {
+	var diskUpdate DiskUpdateInput
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&diskUpdate); err != nil {
+		return err
+	}
+
+	id := mux.Vars(req)["name"]
+	node, err := s.m.GetNode(id)
+	if err != nil {
+		return errors.Wrap(err, "fail to get node")
+	}
+
+	nodeIPMap, err := s.m.GetManagerNodeIPMap()
+	if err != nil {
+		return errors.Wrap(err, "fail to get node ip")
+	}
+
+	originDisks := node.Spec.Disks
+	diskUpdateMap := map[string]types.DiskSpec{}
+	for _, uDisk := range diskUpdate.Disks {
+		diskInfo, err := util.GetDiskInfo(uDisk.Path)
+		if err != nil {
+			return err
+		}
+		// update disks
+		if oDisk, ok := originDisks[diskInfo.Fsid]; ok {
+			if oDisk.Path != uDisk.Path {
+				// current disk is the same file system with exist disk
+				return fmt.Errorf("Add Disk on node %v error: The disk %v is the same file system with %v ", id, uDisk.Path, oDisk.Path)
+			} else if oDisk.StorageMaximum != uDisk.StorageMaximum && uDisk.StorageMaximum != diskInfo.StorageMaximum {
+				logrus.Warnf("StorageMaximum has been changed for disk %v of node %v. Detected maximum storage %v, current setting %v", diskInfo.Path, id, diskInfo.StorageMaximum, uDisk.StorageMaximum)
+			}
+		} else {
+			// add disks
+			if uDisk.StorageMaximum != 0 && uDisk.StorageMaximum != diskInfo.StorageMaximum {
+				logrus.Warnf("StorageMaximum has been changed for disk %v of node %v. Detected maximum storage %v, current setting %v", diskInfo.Path, id, diskInfo.StorageMaximum, uDisk.StorageMaximum)
+			} else {
+				uDisk.StorageMaximum = diskInfo.StorageMaximum
+			}
+		}
+		diskUpdateMap[diskInfo.Fsid] = uDisk
+	}
+
+	// delete disks
+	for fsid, oDisk := range originDisks {
+		if _, ok := diskUpdateMap[fsid]; !ok {
+			if oDisk.AllowScheduling || node.Status.DiskStatus[fsid].StorageScheduled != 0 {
+				return fmt.Errorf("Delete Disk on node %v error: Please disable the disk %v and remove all replicas first ", id, oDisk.Path)
+			}
+		}
+	}
+	node.Spec.Disks = diskUpdateMap
+
+	unode, err := s.m.UpdateNode(node)
+	if err != nil {
+		return err
+	}
+	apiContext.Write(toNodeResource(unode, nodeIPMap[node.Name], apiContext))
 	return nil
 }

--- a/api/router.go
+++ b/api/router.go
@@ -95,8 +95,14 @@ func NewRouter(s *Server) *mux.Router {
 	}
 
 	r.Methods("GET").Path("/v1/nodes").Handler(f(schemas, s.NodeList))
-	r.Methods("GET").Path("/v1/nodes/{id}").Handler(f(schemas, s.NodeGet))
-	r.Methods("PUT").Path("/v1/nodes/{id}").Handler(f(schemas, s.NodeUpdate))
+	r.Methods("GET").Path("/v1/nodes/{name}").Handler(f(schemas, s.NodeGet))
+	r.Methods("PUT").Path("/v1/nodes/{name}").Handler(f(schemas, s.NodeUpdate))
+	nodeActions := map[string]func(http.ResponseWriter, *http.Request) error{
+		"diskUpdate": s.fwd.Handler(OwnerIDFromNode(s.m), s.DiskUpdate),
+	}
+	for name, action := range nodeActions {
+		r.Methods("POST").Path("/v1/nodes/{name}").Queries("action", name).Handler(f(schemas, action))
+	}
 
 	r.Methods("GET").Path("/v1/engineimages").Handler(f(schemas, s.EngineImageList))
 	r.Methods("GET").Path("/v1/engineimages/{name}").Handler(f(schemas, s.EngineImageGet))

--- a/app/daemon.go
+++ b/app/daemon.go
@@ -124,14 +124,7 @@ func startManager(c *cli.Context) error {
 }
 
 func environmentCheck() error {
-	initiatorNSPath := "/host/proc/1/ns"
-	pf := iscsi_util.NewProcessFinder("/host/proc")
-	ps, err := pf.FindAncestorByName("dockerd")
-	if err != nil {
-		logrus.Warnf("Failed to find dockerd in the process ancestors, fall back to use pid 1: %v", err)
-	} else {
-		initiatorNSPath = fmt.Sprintf("/host/proc/%d/ns", ps.Pid)
-	}
+	initiatorNSPath := util.GetInitiatorNSPath()
 	namespace, err := iscsi_util.NewNamespaceExecutor(initiatorNSPath)
 	if err != nil {
 		return err

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -92,7 +92,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		kubeClient, namespace, controllerID)
 	nc := NewNodeController(ds, scheme,
 		nodeInformer, podInformer,
-		kubeClient, namespace)
+		kubeClient, namespace, controllerID)
 	ws := NewWebsocketController(volumeInformer, engineInformer, replicaInformer,
 		settingInformer, engineImageInformer, nodeInformer)
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -42,6 +42,7 @@ const (
 	TestDefaultDataPath = "/var/lib/rancher/longhorn"
 	TestDaemon1         = "longhorn-manager-1"
 	TestDaemon2         = "longhorn-manager-2"
+	TestDiskID1         = "diskID1"
 )
 
 var (

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -39,10 +39,12 @@ const (
 
 	TestTimeNow = "2015-01-02T00:00:00Z"
 
-	TestDefaultDataPath = "/var/lib/rancher/longhorn"
-	TestDaemon1         = "longhorn-manager-1"
-	TestDaemon2         = "longhorn-manager-2"
-	TestDiskID1         = "diskID1"
+	TestDefaultDataPath   = "/var/lib/rancher/longhorn"
+	TestDaemon1           = "longhorn-manager-1"
+	TestDaemon2           = "longhorn-manager-2"
+	TestDiskID1           = "diskID1"
+	TestDiskSize          = 5000000000
+	TestDiskAvailableSize = 3000000000
 )
 
 var (

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -29,7 +29,7 @@ type NodeTestCase struct {
 }
 
 func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
-	lhClient *lhfake.Clientset, kubeClient *fake.Clientset) *NodeController {
+	lhClient *lhfake.Clientset, kubeClient *fake.Clientset, controllerID string) *NodeController {
 	volumeInformer := lhInformerFactory.Longhorn().V1alpha1().Volumes()
 	engineInformer := lhInformerFactory.Longhorn().V1alpha1().Engines()
 	replicaInformer := lhInformerFactory.Longhorn().V1alpha1().Replicas()
@@ -48,7 +48,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		podInformer, cronJobInformer, daemonSetInformer,
 		kubeClient, TestNamespace)
 
-	nc := NewNodeController(ds, scheme.Scheme, nodeInformer, podInformer, kubeClient, TestNamespace)
+	nc := NewNodeController(ds, scheme.Scheme, nodeInformer, podInformer, kubeClient, TestNamespace, controllerID)
 	fakeRecorder := record.NewFakeRecorder(100)
 	nc.eventRecorder = fakeRecorder
 
@@ -138,7 +138,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		nIndexer := lhInformerFactory.Longhorn().V1alpha1().Nodes().Informer().GetIndexer()
 		pIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 
-		nc := newTestNodeController(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient)
+		nc := newTestNodeController(lhInformerFactory, kubeInformerFactory, lhClient, kubeClient, TestNode1)
 		// create manager pod
 		for _, pod := range tc.pods {
 			p, err := kubeClient.CoreV1().Pods(TestNamespace).Create(pod)

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -149,12 +149,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	}
 	tc.pods = pods
 	node1 = newNode(TestNode1, TestNamespace, true, "up")
-	node1.Spec.Disks = map[string]types.DiskSpec{
-		TestDiskID1: {
-			Path:            TestDefaultDataPath,
-			AllowScheduling: true,
-		},
-	}
 	node1.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -162,12 +156,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		},
 	}
 	node2 = newNode(TestNode2, TestNamespace, true, "up")
-	node2.Spec.Disks = map[string]types.DiskSpec{
-		TestDiskID1: {
-			Path:            TestDefaultDataPath,
-			AllowScheduling: true,
-		},
-	}
 	node2.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -514,6 +514,7 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 				// validate DataPath and NodeID of replica have been set in scheduler
 				c.Assert(retR.Spec.DataPath, Not(Equals), "")
 				c.Assert(retR.Spec.NodeID, Not(Equals), "")
+				c.Assert(retR.Spec.DiskID, Not(Equals), "")
 				c.Assert(retR.Spec.NodeID, Equals, TestNode1)
 				c.Assert(retR.Status, DeepEquals, expectR.Status)
 			} else {

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -357,6 +357,14 @@ func newNode(name, namespace string, allowScheduling bool, status types.NodeStat
 		},
 		Spec: types.NodeSpec{
 			AllowScheduling: allowScheduling,
+			Disks: map[string]types.DiskSpec{
+				TestDiskID1: {
+					Path:            TestDefaultDataPath,
+					AllowScheduling: true,
+					StorageMaximum:  0,
+					StorageReserved: 0,
+				},
+			},
 		},
 		Status: types.NodeStatus{
 			State: status,

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -363,7 +363,7 @@ func newNode(name, namespace string, allowScheduling bool, status types.NodeStat
 				TestDiskID1: {
 					Path:            TestDefaultDataPath,
 					AllowScheduling: true,
-					StorageMaximum:  0,
+					StorageMaximum:  TestDiskSize,
 					StorageReserved: 0,
 				},
 			},
@@ -440,6 +440,12 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 
 		// need to create default node
 		for _, node := range tc.nodes {
+			node.Status.DiskStatus = map[string]types.DiskStatus{
+				TestDiskID1: {
+					StorageAvailable: TestDiskAvailableSize,
+					StorageScheduled: 0,
+				},
+			}
 			n, err := lhClient.Longhorn().Nodes(TestNamespace).Create(node)
 			c.Assert(err, IsNil)
 			c.Assert(n, NotNil)

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -589,6 +589,21 @@ func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
 			State: types.NodeStateUp,
 		},
 	}
+	diskInfo, err := util.GetDiskInfo(types.DefaultLonghornDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultDisk := map[string]types.DiskSpec{
+		diskInfo.Fsid: {
+			Path:            diskInfo.Path,
+			StorageMaximum:  diskInfo.StorageMaximum,
+			AllowScheduling: true,
+			StorageReserved: 0,
+		},
+	}
+	node.Spec.Disks = defaultDisk
+
 	return s.CreateNode(node)
 }
 

--- a/k8s/pkg/apis/longhorn/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s/pkg/apis/longhorn/v1alpha1/zz_generated.deepcopy.go
@@ -151,8 +151,8 @@ func (in *Node) DeepCopyInto(out *Node) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
-	out.Status = in.Status
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
 	return
 }
 

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -42,6 +42,7 @@ const (
 	TestDaemon1 = "longhorn-manager-1"
 	TestDaemon2 = "longhorn-manager-2"
 	TestDaemon3 = "longhorn-manager-3"
+	TestDiskID1 = "diskID1"
 )
 
 func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
@@ -89,6 +90,12 @@ func newDaemonPod(phase v1.PodPhase, name, namespace, nodeID, podIP string) *v1.
 }
 
 func newNode(name, namespace string, allowScheduling bool, nodeState types.NodeState) *longhorn.Node {
+	disks := map[string]types.DiskSpec{
+		TestDiskID1: {
+			Path:            TestDefaultDataPath,
+			AllowScheduling: true,
+		},
+	}
 	return &longhorn.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -96,6 +103,7 @@ func newNode(name, namespace string, allowScheduling bool, nodeState types.NodeS
 		},
 		Spec: types.NodeSpec{
 			AllowScheduling: allowScheduling,
+			Disks:           disks,
 		},
 		Status: types.NodeStatus{
 			State: nodeState,

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -42,7 +42,10 @@ const (
 	TestDaemon1 = "longhorn-manager-1"
 	TestDaemon2 = "longhorn-manager-2"
 	TestDaemon3 = "longhorn-manager-3"
-	TestDiskID1 = "diskID1"
+
+	TestDiskID1           = "diskID1"
+	TestDiskSize          = 5000000000
+	TestDiskAvailableSize = 3000000000
 )
 
 func newReplicaScheduler(lhInformerFactory lhinformerfactory.SharedInformerFactory, kubeInformerFactory informers.SharedInformerFactory,
@@ -94,6 +97,8 @@ func newNode(name, namespace string, allowScheduling bool, nodeState types.NodeS
 		TestDiskID1: {
 			Path:            TestDefaultDataPath,
 			AllowScheduling: true,
+			StorageMaximum:  TestDiskSize,
+			StorageReserved: 0,
 		},
 	}
 	return &longhorn.Node{
@@ -198,8 +203,26 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		daemon3,
 	}
 	node1 := newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
+	node1.Status.DiskStatus = map[string]types.DiskStatus{
+		TestDiskID1: {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+		},
+	}
 	node2 := newNode(TestNode2, TestNamespace, false, types.NodeStateUp)
+	node2.Status.DiskStatus = map[string]types.DiskStatus{
+		TestDiskID1: {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+		},
+	}
 	node3 := newNode(TestNode3, TestNamespace, true, types.NodeStateDown)
+	node3.Status.DiskStatus = map[string]types.DiskStatus{
+		TestDiskID1: {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+		},
+	}
 	nodes := map[string]*longhorn.Node{
 		TestNode1: node1,
 		TestNode2: node2,
@@ -222,7 +245,19 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		daemon2,
 	}
 	node1 = newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
+	node1.Status.DiskStatus = map[string]types.DiskStatus{
+		TestDiskID1: {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+		},
+	}
 	node2 = newNode(TestNode2, TestNamespace, true, types.NodeStateUp)
+	node2.Status.DiskStatus = map[string]types.DiskStatus{
+		TestDiskID1: {
+			StorageAvailable: TestDiskAvailableSize,
+			StorageScheduled: 0,
+		},
+	}
 	nodes = map[string]*longhorn.Node{
 		TestNode1: node1,
 		TestNode2: node2,

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -47,3 +47,25 @@ func (e *EngineStatus) DeepCopyInto(to *EngineStatus) {
 		to.ReplicaModeMap[key] = value
 	}
 }
+
+func (n *NodeSpec) DeepCopyInto(to *NodeSpec) {
+	*to = *n
+	if n.Disks == nil {
+		return
+	}
+	to.Disks = make(map[string]DiskSpec)
+	for key, value := range n.Disks {
+		to.Disks[key] = value
+	}
+}
+
+func (n *NodeStatus) DeepCopyInto(to *NodeStatus) {
+	*to = *n
+	if n.DiskStatus == nil {
+		return
+	}
+	to.DiskStatus = make(map[string]DiskStatus)
+	for key, value := range n.DiskStatus {
+		to.DiskStatus[key] = value
+	}
+}

--- a/types/resource.go
+++ b/types/resource.go
@@ -181,8 +181,9 @@ type EngineVersionDetails struct {
 }
 
 type NodeSpec struct {
-	Name            string `json:"name"`
-	AllowScheduling bool   `json:"allowScheduling"`
+	Name            string              `json:"name"`
+	Disks           map[string]DiskSpec `json:"disks"`
+	AllowScheduling bool                `json:"allowScheduling"`
 }
 
 type NodeState string
@@ -193,5 +194,18 @@ const (
 )
 
 type NodeStatus struct {
-	State NodeState
+	State      NodeState             `json:"state"`
+	DiskStatus map[string]DiskStatus `json:"diskStatus"`
+}
+
+type DiskSpec struct {
+	Path            string `json:"path"`
+	AllowScheduling bool   `json:"allowScheduling"`
+	StorageMaximum  int64  `json:"storageMaximum"`
+	StorageReserved int64  `json:"storageReserved"`
+}
+
+type DiskStatus struct {
+	StorageAvailable int64 `json:"storageAvailable"`
+	StorageScheduled int64 `json:"storageScheduled"`
 }

--- a/types/resource.go
+++ b/types/resource.go
@@ -133,6 +133,7 @@ type ReplicaSpec struct {
 	RestoreName string `json:"restoreName"`
 	HealthyAt   string `json:"healthyAt"`
 	FailedAt    string `json:"failedAt"`
+	DiskID      string `json:"diskID"`
 	DataPath    string `json:"dataPath"`
 	Active      bool   `json:"active"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -50,6 +50,10 @@ const (
 	OptionFrontend            = "frontend"
 
 	EngineImageChecksumNameLength = 8
+
+	// StorageOverProvisioningPercentage and StorageMinimalAvailablePercentage will be set in next phase
+	StorageOverProvisioningPercentage = 100
+	StorageMinimalAvailablePercentage = 0
 )
 
 type NotFoundError struct {

--- a/types/types.go
+++ b/types/types.go
@@ -20,6 +20,8 @@ const (
 	// DefaultLonghornDirectory is the directory going to be bind mounted on the
 	// host to provide storage space to replica data by default
 	DefaultLonghornDirectory = "/var/lib/rancher/longhorn/"
+
+	LonghornNodeKey = "longhornnode"
 )
 
 const (


### PR DESCRIPTION
Phase 2(https://github.com/rancher/longhorn/issues/47):
- [x] Add multiple disks to Node CRD
- [x] Update Node API for UI, user could add/remove/disable scheduling for the disk
- [x] Update Node Controller to update disks status
- [x] Unit test for Node Controller
- [x] Update Replica Scheduler. Add multiple disks scheduling logic into scheduler.
- [x] Unit test for replica scheduler
- [x] Add integration test to longhorn-tests

integration test for Phase 2(https://github.com/rancher/longhorn-tests/pull/74)