### PR TITLE
Automatically figure out which driver to use

### DIFF
--- a/csi/deployment.go
+++ b/csi/deployment.go
@@ -1,0 +1,299 @@
+package csi
+
+import (
+	"github.com/Sirupsen/logrus"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/util/pointer"
+)
+
+const (
+	DefaultCSIAttacherImage        = "quay.io/k8scsi/csi-attacher:v0.2.0"
+	DefaultCSIProvisionerImage     = "quay.io/k8scsi/csi-provisioner:v0.2.0"
+	DefaultCSIDriverRegistrarImage = "quay.io/k8scsi/driver-registrar:v0.2.0"
+	DefaultCSIProvisionerName      = "rancher.io/longhorn"
+)
+
+var (
+	HostPathDirectoryOrCreate     = v1.HostPathDirectoryOrCreate
+	MountPropagationBidirectional = v1.MountPropagationBidirectional
+)
+
+type AttacherDeployment struct {
+	service     *v1.Service
+	statefulSet *appsv1beta1.StatefulSet
+}
+
+func NewAttacherDeployment(namespace, serviceAccount, attacherImage string) *AttacherDeployment {
+	service := getCommonService("csi-attacher", namespace)
+
+	statefulSet := getCommondStatefulSet(
+		"csi-attacher",
+		namespace,
+		serviceAccount,
+		attacherImage,
+		[]string{
+			"--v=5",
+			"--csi-address=$(ADDRESS)",
+		},
+	)
+
+	return &AttacherDeployment{
+		service:     service,
+		statefulSet: statefulSet,
+	}
+}
+
+func (a *AttacherDeployment) Deploy(kubeClient *clientset.Clientset) error {
+	if err := deployService(kubeClient, a.service); err != nil {
+		return err
+	}
+
+	return deployStatefulSet(kubeClient, a.statefulSet)
+}
+
+func (a *AttacherDeployment) Cleanup(kubeClient *clientset.Clientset) {
+	if err := cleanupService(kubeClient, a.service); err != nil {
+		logrus.Warnf("Failed to cleanup Service in attacher deployment: %v", err)
+	}
+
+	if err := cleanupStatefulSet(kubeClient, a.statefulSet); err != nil {
+		logrus.Warnf("Failed to cleanup StatefulSet in attacher deployment: %v", err)
+	}
+}
+
+type ProvisionerDeployment struct {
+	service     *v1.Service
+	statefulSet *appsv1beta1.StatefulSet
+}
+
+func NewProvisionerDeployment(namespace, serviceAccount, provisionerImage, provisionerName string) *ProvisionerDeployment {
+	service := getCommonService("csi-provisioner", namespace)
+
+	statefulSet := getCommondStatefulSet(
+		"csi-provisioner",
+		namespace,
+		serviceAccount,
+		provisionerImage,
+		[]string{
+			"--provisioner=" + provisionerName,
+			"--csi-address=$(ADDRESS)",
+			"--v=5",
+		},
+	)
+
+	return &ProvisionerDeployment{
+		service:     service,
+		statefulSet: statefulSet,
+	}
+}
+
+func (p *ProvisionerDeployment) Deploy(kubeClient *clientset.Clientset) error {
+	if err := deployService(kubeClient, p.service); err != nil {
+		return err
+	}
+
+	return deployStatefulSet(kubeClient, p.statefulSet)
+}
+
+func (p *ProvisionerDeployment) Cleanup(kubeClient *clientset.Clientset) {
+	if err := cleanupService(kubeClient, p.service); err != nil {
+		logrus.Warnf("Failed to cleanup Service in provisioner deployment: %v", err)
+	}
+
+	if err := cleanupStatefulSet(kubeClient, p.statefulSet); err != nil {
+		logrus.Warnf("Failed to cleanup StatefulSet in provisioner deployment: %v", err)
+	}
+}
+
+type PluginDeployment struct {
+	daemonSet *appsv1beta2.DaemonSet
+}
+
+func NewPluginDeployment(namespace, serviceAccount, driverRegistrarImage, managerImage string) *PluginDeployment {
+	daemonSet := &appsv1beta2.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "longhorn-csi-plugin",
+			Namespace: namespace,
+		},
+
+		Spec: appsv1beta2.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "longhorn-csi-plugin",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "longhorn-csi-plugin",
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: serviceAccount,
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  "driver-registrar",
+							Image: driverRegistrarImage,
+							Args: []string{
+								"--v=5",
+								"--csi-address=$(ADDRESS)",
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name:  "ADDRESS",
+									Value: "/var/lib/kubelet/plugins/io.rancher.longhorn/csi.sock",
+								},
+								v1.EnvVar{
+									Name: "KUBE_NODE_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
+							//ImagePullPolicy: v1.PullAlways,
+							VolumeMounts: []v1.VolumeMount{
+								v1.VolumeMount{
+									Name:      "socket-dir",
+									MountPath: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+								},
+							},
+						},
+						v1.Container{
+							Name: "longhorn-csi-plugin",
+							SecurityContext: &v1.SecurityContext{
+								Privileged: pointer.BoolPtr(true),
+								Capabilities: &v1.Capabilities{
+									Add: []v1.Capability{
+										"SYS_ADMIN",
+									},
+								},
+								AllowPrivilegeEscalation: pointer.BoolPtr(true),
+							},
+							Image: managerImage,
+							Args: []string{
+								"longhorn-manager",
+								"-d",
+								"csi",
+								"--nodeid=$(NODE_ID)",
+								"--endpoint=$(CSI_ENDPOINT)",
+								"--drivername=io.rancher.longhorn",
+								"--manager-url=http://longhorn-backend:9500/v1",
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "NODE_ID",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name:  "CSI_ENDPOINT",
+									Value: "unix://var/lib/kubelet/plugins/io.rancher.longhorn/csi.sock",
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								v1.VolumeMount{
+									Name:      "plugin-dir",
+									MountPath: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+								},
+								v1.VolumeMount{
+									Name:             "pods-mount-dir",
+									MountPath:        "/var/lib/kubelet/pods",
+									MountPropagation: &MountPropagationBidirectional,
+								},
+								v1.VolumeMount{
+									Name:      "host-dev",
+									MountPath: "/dev",
+								},
+								v1.VolumeMount{
+									Name:      "host-sys",
+									MountPath: "/sys",
+								},
+								v1.VolumeMount{
+									Name:      "lib-modules",
+									MountPath: "/lib/modules",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						v1.Volume{
+							Name: "plugin-dir",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+									Type: &HostPathDirectoryOrCreate,
+								},
+							},
+						},
+						v1.Volume{
+							Name: "pods-mount-dir",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet/pods",
+									Type: &HostPathDirectoryOrCreate,
+								},
+							},
+						},
+						v1.Volume{
+							Name: "socket-dir",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+									Type: &HostPathDirectoryOrCreate,
+								},
+							},
+						},
+						v1.Volume{
+							Name: "host-dev",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/dev",
+								},
+							},
+						},
+						v1.Volume{
+							Name: "host-sys",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/sys",
+								},
+							},
+						},
+						v1.Volume{
+							Name: "lib-modules",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/lib-modules",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return &PluginDeployment{
+		daemonSet: daemonSet,
+	}
+}
+
+func (p *PluginDeployment) Deploy(kubeClient *clientset.Clientset) error {
+	return deployDaemonSet(kubeClient, p.daemonSet)
+}
+
+func (p *PluginDeployment) Cleanup(kubeClient *clientset.Clientset) {
+	if err := cleanupDaemonSet(kubeClient, p.daemonSet); err != nil {
+		logrus.Warnf("Failed to cleanup DaemonSet in plugin deployment: %v", err)
+	}
+}

--- a/csi/deployment_util.go
+++ b/csi/deployment_util.go
@@ -1,0 +1,185 @@
+package csi
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func getCommonService(commonName, namespace string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      commonName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": commonName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": commonName,
+			},
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name: "dummy",
+					Port: 12345,
+				},
+			},
+		},
+	}
+}
+
+func getCommondStatefulSet(commonName, namespace, serviceAccount, image string, args []string) *appsv1beta1.StatefulSet {
+	return &appsv1beta1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      commonName,
+			Namespace: namespace,
+		},
+		Spec: appsv1beta1.StatefulSetSpec{
+			ServiceName: commonName,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": commonName,
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: serviceAccount,
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  commonName,
+							Image: image,
+							Args:  args,
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name:  "ADDRESS",
+									Value: "/var/lib/kubelet/plugins/io.rancher.longhorn/csi.sock",
+								},
+							},
+							//ImagePullPolicy: v1.PullAlways,
+							VolumeMounts: []v1.VolumeMount{
+								v1.VolumeMount{
+									Name:      "socket-dir",
+									MountPath: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						v1.Volume{
+							Name: "socket-dir",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet/plugins/io.rancher.longhorn",
+									Type: &HostPathDirectoryOrCreate,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cleanupService(kubeClient *clientset.Clientset, service *v1.Service) error {
+	logrus.Debugf("Trying to get service %s", service.ObjectMeta.Name)
+	svc, err := kubeClient.CoreV1().Services(service.ObjectMeta.Namespace).Get(service.ObjectMeta.Name, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if svc != nil && svc.DeletionTimestamp != nil {
+		return fmt.Errorf("Object is being deleted: service %s", service.ObjectMeta.Name)
+	}
+
+	if svc != nil {
+		logrus.Debugf("Trying to delete service %s", service.ObjectMeta.Name)
+		propagation := metav1.DeletePropagationForeground
+		if err = kubeClient.CoreV1().Services(service.ObjectMeta.Namespace).Delete(service.ObjectMeta.Name,
+			&metav1.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deployService(kubeClient *clientset.Clientset, service *v1.Service) error {
+	if err := cleanupService(kubeClient, service); err != nil {
+		return err
+	}
+	logrus.Debugf("Trying to create service %s", service.ObjectMeta.Name)
+	if _, err := kubeClient.CoreV1().Services(service.ObjectMeta.Namespace).Create(service); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupStatefulSet(kubeClient *clientset.Clientset, statefulSet *appsv1beta1.StatefulSet) error {
+	logrus.Debugf("Trying to get statefulSet %s", statefulSet.ObjectMeta.Name)
+	sfs, err := kubeClient.AppsV1beta1().StatefulSets(statefulSet.ObjectMeta.Namespace).Get(statefulSet.ObjectMeta.Name, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if sfs != nil && sfs.DeletionTimestamp != nil {
+		return fmt.Errorf("Object is being deleted: statefulSet %s", statefulSet.ObjectMeta.Name)
+	}
+
+	if sfs != nil {
+		logrus.Debugf("Trying to delete statefulSet %s", statefulSet.ObjectMeta.Name)
+		propagation := metav1.DeletePropagationForeground
+		if err = kubeClient.AppsV1beta1().StatefulSets(statefulSet.ObjectMeta.Namespace).Delete(statefulSet.ObjectMeta.Name,
+			&metav1.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deployStatefulSet(kubeClient *clientset.Clientset, statefulSet *appsv1beta1.StatefulSet) error {
+	if err := cleanupStatefulSet(kubeClient, statefulSet); err != nil {
+		return err
+	}
+	logrus.Debugf("Trying to create statefulSet %s", statefulSet.ObjectMeta.Name)
+	if _, err := kubeClient.AppsV1beta1().StatefulSets(statefulSet.ObjectMeta.Namespace).Create(statefulSet); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupDaemonSet(kubeClient *clientset.Clientset, daemonSet *appsv1beta2.DaemonSet) error {
+	logrus.Debugf("Trying to get daemonset %s", daemonSet.ObjectMeta.Name)
+	ds, err := kubeClient.AppsV1beta2().DaemonSets(daemonSet.ObjectMeta.Namespace).Get(daemonSet.ObjectMeta.Name, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if ds != nil && ds.DeletionTimestamp != nil {
+		return fmt.Errorf("Object is being deleted: DaemonSet %s", daemonSet.ObjectMeta.Name)
+	}
+
+	if ds != nil {
+		logrus.Debugf("Trying to delete daemonset %s", daemonSet.ObjectMeta.Name)
+		propagation := metav1.DeletePropagationForeground
+		if err = kubeClient.AppsV1beta2().DaemonSets(daemonSet.ObjectMeta.Namespace).Delete(daemonSet.ObjectMeta.Name,
+			&metav1.DeleteOptions{PropagationPolicy: &propagation}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deployDaemonSet(kubeClient *clientset.Clientset, daemonSet *appsv1beta2.DaemonSet) error {
+	if err := cleanupDaemonSet(kubeClient, daemonSet); err != nil {
+		return err
+	}
+	logrus.Debugf("Trying to create daemonset %s", daemonSet.ObjectMeta.Name)
+	if _, err := kubeClient.AppsV1beta2().DaemonSets(daemonSet.ObjectMeta.Namespace).Create(daemonSet); err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	a.Commands = []cli.Command{
 		app.DaemonCmd(),
 		app.SnapshotCmd(),
-		app.DeployFlexvolumeDriverCmd(),
+		app.DeployDriverCmd(),
 		app.CSICommand(),
 	}
 	a.CommandNotFound = cmdNotFound

--- a/types/types.go
+++ b/types/types.go
@@ -22,6 +22,10 @@ const (
 	DefaultLonghornDirectory = "/var/lib/rancher/longhorn/"
 )
 
+const (
+	CSIKubernetesMinVersion = "v1.10.0"
+)
+
 type ReplicaMode string
 
 const (
@@ -29,9 +33,10 @@ const (
 	ReplicaModeWO  = ReplicaMode("WO")
 	ReplicaModeERR = ReplicaMode("ERR")
 
-	EnvNodeName     = "NODE_NAME"
-	EnvPodNamespace = "POD_NAMESPACE"
-	EnvPodIP        = "POD_IP"
+	EnvNodeName       = "NODE_NAME"
+	EnvPodNamespace   = "POD_NAMESPACE"
+	EnvPodIP          = "POD_IP"
+	EnvServiceAccount = "SERVICE_ACCOUNT"
 
 	AWSAccessKey = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
1. If it’s v1.8 or v1.9, Flexvolume Plugin would be deployed.
   No configuration needed for 1.8 (because we can detect the location using an alpha API).
   User will need to set the FLEXVOLUME_DIR manually in the yaml file for 1.9.
2. If it’s v1.10+, CSI would be deployed. No configuration needed.
3. The choice can be overridden in the command line.
4. If CSI driver has been chosen, the built-in Longhorn provisioner must be disabled.
5. If user choose to override the default choice, he will need to
   provide additional command line parameter to longhorn manager in
   addition to the longhorn driver deployer.


