### PR TITLE
Multiple disk with capacity based scheduling(Phase3)

### DIFF
--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -91,7 +91,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		engineImageInformer, volumeInformer, daemonSetInformer,
 		kubeClient, namespace, controllerID)
 	nc := NewNodeController(ds, scheme,
-		nodeInformer, podInformer,
+		nodeInformer, settingInformer, podInformer,
 		kubeClient, namespace, controllerID)
 	ws := NewWebsocketController(volumeInformer, engineInformer, replicaInformer,
 		settingInformer, engineImageInformer, nodeInformer)

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -49,7 +49,7 @@ func newTestNodeController(lhInformerFactory lhinformerfactory.SharedInformerFac
 		podInformer, cronJobInformer, daemonSetInformer,
 		kubeClient, TestNamespace)
 
-	nc := NewNodeController(ds, scheme.Scheme, nodeInformer, podInformer, kubeClient, TestNamespace, controllerID)
+	nc := NewNodeController(ds, scheme.Scheme, nodeInformer, settingInformer, podInformer, kubeClient, TestNamespace, controllerID)
 	fakeRecorder := record.NewFakeRecorder(100)
 	nc.eventRecorder = fakeRecorder
 
@@ -153,6 +153,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDiskID1: {
 			StorageScheduled: 0,
 			StorageAvailable: 0,
+			State:            types.DiskStateSchedulable,
 		},
 	}
 	node2 = newNode(TestNode2, TestNamespace, true, "up")
@@ -180,6 +181,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: TestVolumeSize,
+					State:            types.DiskStateUnschedulable,
 				},
 			},
 		},

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -691,4 +692,26 @@ func tagNodeLabel(replica *longhorn.Replica) error {
 	}
 	metadata.SetLabels(labels)
 	return nil
+}
+
+func (s *DataStore) GetSettingAsInt(settingName types.SettingName) (int64, error) {
+	definition, ok := types.SettingDefinitions[settingName]
+	if !ok {
+		return 0, fmt.Errorf("setting %v is not supported", settingName)
+	}
+	settings, err := s.GetSetting(settingName)
+	if err != nil {
+		return 0, err
+	}
+	value := settings.Value
+
+	if definition.Type == types.SettingTypeInt {
+		result, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return result, nil
+	}
+
+	return 0, fmt.Errorf("The %v setting value couldn't change to integer, value is %v ", string(settingName), value)
 }

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -293,10 +293,12 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
+			State:            types.DiskStateSchedulable,
 		},
 		TestDiskID2: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
+			State:            types.DiskStateSchedulable,
 		},
 	}
 	expectNode1 := newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
@@ -312,6 +314,7 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
+			State:            types.DiskStateSchedulable,
 		},
 	}
 	nodes = map[string]*longhorn.Node{

--- a/types/resource.go
+++ b/types/resource.go
@@ -206,7 +206,15 @@ type DiskSpec struct {
 	StorageReserved int64  `json:"storageReserved"`
 }
 
+type DiskState string
+
+const (
+	DiskStateSchedulable   = DiskState("schedulable")
+	DiskStateUnschedulable = DiskState("unschedulable")
+)
+
 type DiskStatus struct {
+	State            DiskState
 	StorageAvailable int64 `json:"storageAvailable"`
 	StorageScheduled int64 `json:"storageScheduled"`
 }

--- a/types/setting.go
+++ b/types/setting.go
@@ -15,9 +15,11 @@ const (
 type SettingName string
 
 const (
-	SettingNameBackupTarget                 = SettingName("backup-target")
-	SettingNameBackupTargetCredentialSecret = SettingName("backup-target-credential-secret")
-	SettingNameDefaultEngineImage           = SettingName("default-engine-image")
+	SettingNameBackupTarget                      = SettingName("backup-target")
+	SettingNameBackupTargetCredentialSecret      = SettingName("backup-target-credential-secret")
+	SettingNameDefaultEngineImage                = SettingName("default-engine-image")
+	SettingNameStorageOverProvisioningPercentage = SettingName("storage-over-provisioning-percentage")
+	SettingNameStorageMinimalAvailablePercentage = SettingName("storage-minimal-available-percentage")
 )
 
 type SettingCategory string
@@ -40,9 +42,11 @@ type SettingDefinition struct {
 
 var (
 	SettingDefinitions = map[SettingName]SettingDefinition{
-		SettingNameBackupTarget:                 SettingDefinitionBackupTarget,
-		SettingNameBackupTargetCredentialSecret: SettingDefinitionBackupTargetCredentialSecret,
-		SettingNameDefaultEngineImage:           SettingDefinitionDefaultEngineImage,
+		SettingNameBackupTarget:                      SettingDefinitionBackupTarget,
+		SettingNameBackupTargetCredentialSecret:      SettingDefinitionBackupTargetCredentialSecret,
+		SettingNameDefaultEngineImage:                SettingDefinitionDefaultEngineImage,
+		SettingNameStorageOverProvisioningPercentage: SettingDefinitionStorageOverProvisioningPercentage,
+		SettingNameStorageMinimalAvailablePercentage: SettingDefinitionStorageMinimalAvailablePercentage,
 	}
 
 	SettingDefinitionBackupTarget = SettingDefinition{
@@ -70,5 +74,25 @@ var (
 		Type:        SettingTypeString,
 		Required:    true,
 		ReadOnly:    true,
+	}
+
+	SettingDefinitionStorageOverProvisioningPercentage = SettingDefinition{
+		DisplayName: "Storage Over Provisioning Percentage",
+		Description: "The over-provisioning percentage defines how much storage can be allocated relative to the hard drive's capacity",
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeInt,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "500",
+	}
+
+	SettingDefinitionStorageMinimalAvailablePercentage = SettingDefinition{
+		DisplayName: "Storage Minimal Available Percentage",
+		Description: "If one disk's available capacity to it's maximum capacity in % is less than the minimal available percentage, the disk would become unschedulable until more space freed up.",
+		Category:    SettingCategoryScheduling,
+		Type:        SettingTypeInt,
+		Required:    true,
+		ReadOnly:    false,
+		Default:     "10",
 	}
 )

--- a/types/types.go
+++ b/types/types.go
@@ -50,10 +50,6 @@ const (
 	OptionFrontend            = "frontend"
 
 	EngineImageChecksumNameLength = 8
-
-	// StorageOverProvisioningPercentage and StorageMinimalAvailablePercentage will be set in next phase
-	StorageOverProvisioningPercentage = 100
-	StorageMinimalAvailablePercentage = 0
 )
 
 type NotFoundError struct {


### PR DESCRIPTION
Phase 3(https://github.com/rancher/longhorn/issues/47):
- [x] Add `State` to DiskStatus
- [x] Add `StorageOverProvisioningPercentage` and `StorageMinimalAvailablePercentage` to settings
- [x] Update Node Controller to watch `StorageOverProvisioningPercentage` and `StorageMinimalAvailablePercentage` settings and update `DiskState`
- [x] Update Replica Scheduler logic, using `StorageOverProvisioningPercentage` and `StorageMinimalAvailablePercentage` from settings
- [x] Update replica scheduler tests
- [x] Add integration tests for `DiskState` and over-provisioning and minimal available storage settings

integration test for Phase3(https://github.com/rancher/longhorn-tests/pull/81)