### PR TITLE
Fix StorageClass example

### DIFF
--- a/example/example_storageclass.yaml
+++ b/example/example_storageclass.yaml
@@ -6,7 +6,7 @@ provisioner: rancher.io/longhorn
 parameters:
   numberOfReplicas: '3'
   staleReplicaTimeout: '30'
-reclaimPolicy: delete
+reclaimPolicy: Delete
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
Apparently missed this typo when I was writing the examples.

The `reclaimPolicy` was set as lowercase delete, causing issues since Kubernetes didn't recognize that as an acceptable policy.