### PR TITLE
provisioner:Add default values for volume

### DIFF
--- a/controller/provisioner.go
+++ b/controller/provisioner.go
@@ -45,11 +45,20 @@ func (p *Provisioner) Provision(opts pvController.VolumeOptions) (*v1.Persistent
 		return nil, fmt.Errorf("ReadWriteMany access mode is not supported")
 	}
 	resourceStorage := pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	numberOfReplicas, err := strconv.Atoi(opts.Parameters[types.OptionNumberOfReplica])
+	numberOfReplicasParam := types.DefaultNumberOfReplicas
+	if _, ok := opts.Parameters[types.OptionNumberOfReplicas]; ok {
+		numberOfReplicasParam = opts.Parameters[types.OptionNumberOfReplicas]
+	}
+	numberOfReplicas, err := strconv.Atoi(numberOfReplicasParam)
 	if err != nil {
 		return nil, err
 	}
-	staleReplicaTimeout, err := strconv.Atoi(opts.Parameters[types.OptionStaleReplicaTimeout])
+
+	optionStaleReplicaTimeoutParam := types.DefaultStaleReplicaTimeout
+	if _, ok := opts.Parameters[types.OptionStaleReplicaTimeout]; ok {
+		optionStaleReplicaTimeoutParam = opts.Parameters[types.OptionStaleReplicaTimeout]
+	}
+	staleReplicaTimeout, err := strconv.Atoi(optionStaleReplicaTimeoutParam)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +98,7 @@ func (p *Provisioner) Provision(opts pvController.VolumeOptions) (*v1.Persistent
 					FSType: opts.Parameters["fsType"],
 					Options: map[string]string{
 						types.OptionFromBackup:          v.FromBackup,
-						types.OptionNumberOfReplica:     strconv.FormatInt(v.NumberOfReplicas, 10),
+						types.OptionNumberOfReplicas:    strconv.FormatInt(v.NumberOfReplicas, 10),
 						types.OptionStaleReplicaTimeout: strconv.FormatInt(v.StaleReplicaTimeout, 10),
 					},
 				},

--- a/types/types.go
+++ b/types/types.go
@@ -45,9 +45,12 @@ const (
 	AWSEndPoint  = "AWS_ENDPOINTS"
 
 	OptionFromBackup          = "fromBackup"
-	OptionNumberOfReplica     = "numberOfReplicas"
+	OptionNumberOfReplicas    = "numberOfReplicas"
 	OptionStaleReplicaTimeout = "staleReplicaTimeout"
 	OptionFrontend            = "frontend"
+
+	DefaultNumberOfReplicas    = "3"
+	DefaultStaleReplicaTimeout = "30"
 
 	EngineImageChecksumNameLength = 8
 )


### PR DESCRIPTION
If the storageclass definition doesn't contain default value for `numberOfReplicas` and `staleReplicaTimeout`, we will have error in provisioner. So we need to add default value for these two parameters.
Fix issue(https://github.com/rancher/longhorn/issues/123)