### PR TITLE
Change some of node status parameters to node.Status.Condition

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -164,10 +164,10 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("diskUpdate", types.DiskSpec{})
 	schemas.AddType("nodeInput", NodeInput{})
 	schemas.AddType("settingDefinition", types.SettingDefinition{})
-	schemas.AddType("diskInfo", DiskInfo{})
 	// to avoid duplicate name with built-in type condition
 	schemas.AddType("volumeCondition", types.Condition{})
 	schemas.AddType("nodeCondition", types.Condition{})
+	schemas.AddType("diskCondition", types.Condition{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))
@@ -176,6 +176,7 @@ func NewSchema() *client.Schemas {
 	engineImageSchema(schemas.AddType("engineImage", EngineImage{}))
 	nodeSchema(schemas.AddType("node", Node{}))
 	diskSchema(schemas.AddType("diskUpdateInput", DiskUpdateInput{}))
+	diskInfoSchema(schemas.AddType("diskInfo", DiskInfo{}))
 
 	return schemas
 }
@@ -208,6 +209,12 @@ func diskSchema(diskUpdateInput *client.Schema) {
 	disks := diskUpdateInput.ResourceFields["disks"]
 	disks.Type = "array[diskUpdate]"
 	diskUpdateInput.ResourceFields["disks"] = disks
+}
+
+func diskInfoSchema(diskInfo *client.Schema) {
+	conditions := diskInfo.ResourceFields["conditions"]
+	conditions.Type = "map[diskCondition]"
+	diskInfo.ResourceFields["conditions"] = conditions
 }
 
 func engineImageSchema(engineImage *client.Schema) {

--- a/api/model.go
+++ b/api/model.go
@@ -128,12 +128,11 @@ type NodeInput struct {
 
 type Node struct {
 	client.Resource
-	Name             string                                      `json:"name"`
-	Address          string                                      `json:"address"`
-	AllowScheduling  bool                                        `json:"allowScheduling"`
-	Disks            map[string]DiskInfo                         `json:"disks"`
-	Conditions       map[types.NodeConditionType]types.Condition `json:"conditions"`
-	MountPropagation bool                                        `json:"mountPropagation"`
+	Name            string                                      `json:"name"`
+	Address         string                                      `json:"address"`
+	AllowScheduling bool                                        `json:"allowScheduling"`
+	Disks           map[string]DiskInfo                         `json:"disks"`
+	Conditions      map[types.NodeConditionType]types.Condition `json:"conditions"`
 }
 
 type DiskInfo struct {
@@ -627,11 +626,10 @@ func toNodeResource(node *longhorn.Node, address string, apiContext *api.ApiCont
 			Actions: map[string]string{},
 			Links:   map[string]string{},
 		},
-		Name:             node.Name,
-		Address:          address,
-		AllowScheduling:  node.Spec.AllowScheduling,
-		Conditions:       node.Status.Conditions,
-		MountPropagation: node.Status.MountPropagation,
+		Name:            node.Name,
+		Address:         address,
+		AllowScheduling: node.Spec.AllowScheduling,
+		Conditions:      node.Status.Conditions,
 	}
 
 	disks := map[string]DiskInfo{}

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -18,9 +18,10 @@ type RancherClient struct {
 	Controller         ControllerOperations
 	DiskUpdate         DiskUpdateOperations
 	NodeInput          NodeInputOperations
-	VolumeCondition    VolumeConditionOperations
 	SettingDefinition  SettingDefinitionOperations
 	DiskInfo           DiskInfoOperations
+	VolumeCondition    VolumeConditionOperations
+	NodeCondition      NodeConditionOperations
 	Volume             VolumeOperations
 	BackupVolume       BackupVolumeOperations
 	Setting            SettingOperations
@@ -50,9 +51,10 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.Controller = newControllerClient(client)
 	client.DiskUpdate = newDiskUpdateClient(client)
 	client.NodeInput = newNodeInputClient(client)
-	client.VolumeCondition = newVolumeConditionClient(client)
 	client.SettingDefinition = newSettingDefinitionClient(client)
 	client.DiskInfo = newDiskInfoClient(client)
+	client.VolumeCondition = newVolumeConditionClient(client)
+	client.NodeCondition = newNodeConditionClient(client)
 	client.Volume = newVolumeClient(client)
 	client.BackupVolume = newBackupVolumeClient(client)
 	client.Setting = newSettingClient(client)

--- a/client/generated_client.go
+++ b/client/generated_client.go
@@ -19,9 +19,9 @@ type RancherClient struct {
 	DiskUpdate         DiskUpdateOperations
 	NodeInput          NodeInputOperations
 	SettingDefinition  SettingDefinitionOperations
-	DiskInfo           DiskInfoOperations
 	VolumeCondition    VolumeConditionOperations
 	NodeCondition      NodeConditionOperations
+	DiskCondition      DiskConditionOperations
 	Volume             VolumeOperations
 	BackupVolume       BackupVolumeOperations
 	Setting            SettingOperations
@@ -29,6 +29,7 @@ type RancherClient struct {
 	EngineImage        EngineImageOperations
 	Node               NodeOperations
 	DiskUpdateInput    DiskUpdateInputOperations
+	DiskInfo           DiskInfoOperations
 }
 
 func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
@@ -52,9 +53,9 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.DiskUpdate = newDiskUpdateClient(client)
 	client.NodeInput = newNodeInputClient(client)
 	client.SettingDefinition = newSettingDefinitionClient(client)
-	client.DiskInfo = newDiskInfoClient(client)
 	client.VolumeCondition = newVolumeConditionClient(client)
 	client.NodeCondition = newNodeConditionClient(client)
+	client.DiskCondition = newDiskConditionClient(client)
 	client.Volume = newVolumeClient(client)
 	client.BackupVolume = newBackupVolumeClient(client)
 	client.Setting = newSettingClient(client)
@@ -62,6 +63,7 @@ func constructClient(rancherBaseClient *RancherBaseClientImpl) *RancherClient {
 	client.EngineImage = newEngineImageClient(client)
 	client.Node = newNodeClient(client)
 	client.DiskUpdateInput = newDiskUpdateInputClient(client)
+	client.DiskInfo = newDiskInfoClient(client)
 
 	return client
 }

--- a/client/generated_disk_condition.go
+++ b/client/generated_disk_condition.go
@@ -1,0 +1,87 @@
+package client
+
+const (
+	DISK_CONDITION_TYPE = "diskCondition"
+)
+
+type DiskCondition struct {
+	Resource `yaml:"-"`
+
+	LastProbeTime string `json:"lastProbeTime,omitempty" yaml:"last_probe_time,omitempty"`
+
+	LastTransitionTime string `json:"lastTransitionTime,omitempty" yaml:"last_transition_time,omitempty"`
+
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
+
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type DiskConditionCollection struct {
+	Collection
+	Data   []DiskCondition `json:"data,omitempty"`
+	client *DiskConditionClient
+}
+
+type DiskConditionClient struct {
+	rancherClient *RancherClient
+}
+
+type DiskConditionOperations interface {
+	List(opts *ListOpts) (*DiskConditionCollection, error)
+	Create(opts *DiskCondition) (*DiskCondition, error)
+	Update(existing *DiskCondition, updates interface{}) (*DiskCondition, error)
+	ById(id string) (*DiskCondition, error)
+	Delete(container *DiskCondition) error
+}
+
+func newDiskConditionClient(rancherClient *RancherClient) *DiskConditionClient {
+	return &DiskConditionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *DiskConditionClient) Create(container *DiskCondition) (*DiskCondition, error) {
+	resp := &DiskCondition{}
+	err := c.rancherClient.doCreate(DISK_CONDITION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *DiskConditionClient) Update(existing *DiskCondition, updates interface{}) (*DiskCondition, error) {
+	resp := &DiskCondition{}
+	err := c.rancherClient.doUpdate(DISK_CONDITION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *DiskConditionClient) List(opts *ListOpts) (*DiskConditionCollection, error) {
+	resp := &DiskConditionCollection{}
+	err := c.rancherClient.doList(DISK_CONDITION_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *DiskConditionCollection) Next() (*DiskConditionCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &DiskConditionCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *DiskConditionClient) ById(id string) (*DiskCondition, error) {
+	resp := &DiskCondition{}
+	err := c.rancherClient.doById(DISK_CONDITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *DiskConditionClient) Delete(container *DiskCondition) error {
+	return c.rancherClient.doResourceDelete(DISK_CONDITION_TYPE, &container.Resource)
+}

--- a/client/generated_disk_info.go
+++ b/client/generated_disk_info.go
@@ -9,9 +9,9 @@ type DiskInfo struct {
 
 	AllowScheduling bool `json:"allowScheduling,omitempty" yaml:"allow_scheduling,omitempty"`
 
-	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Conditions map[string]interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 
-	State string `json:"state,omitempty" yaml:"state,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	StorageAvailable int64 `json:"storageAvailable,omitempty" yaml:"storage_available,omitempty"`
 

--- a/client/generated_node.go
+++ b/client/generated_node.go
@@ -15,8 +15,6 @@ type Node struct {
 
 	Disks map[string]interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
 
-	MountPropagation bool `json:"mountPropagation,omitempty" yaml:"mount_propagation,omitempty"`
-
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 

--- a/client/generated_node.go
+++ b/client/generated_node.go
@@ -11,13 +11,13 @@ type Node struct {
 
 	AllowScheduling bool `json:"allowScheduling,omitempty" yaml:"allow_scheduling,omitempty"`
 
+	Conditions map[string]interface{} `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+
 	Disks map[string]interface{} `json:"disks,omitempty" yaml:"disks,omitempty"`
 
 	MountPropagation bool `json:"mountPropagation,omitempty" yaml:"mount_propagation,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
-
-	State string `json:"state,omitempty" yaml:"state,omitempty"`
 }
 
 type NodeCollection struct {

--- a/client/generated_node_condition.go
+++ b/client/generated_node_condition.go
@@ -1,0 +1,87 @@
+package client
+
+const (
+	NODE_CONDITION_TYPE = "nodeCondition"
+)
+
+type NodeCondition struct {
+	Resource `yaml:"-"`
+
+	LastProbeTime string `json:"lastProbeTime,omitempty" yaml:"last_probe_time,omitempty"`
+
+	LastTransitionTime string `json:"lastTransitionTime,omitempty" yaml:"last_transition_time,omitempty"`
+
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
+
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type NodeConditionCollection struct {
+	Collection
+	Data   []NodeCondition `json:"data,omitempty"`
+	client *NodeConditionClient
+}
+
+type NodeConditionClient struct {
+	rancherClient *RancherClient
+}
+
+type NodeConditionOperations interface {
+	List(opts *ListOpts) (*NodeConditionCollection, error)
+	Create(opts *NodeCondition) (*NodeCondition, error)
+	Update(existing *NodeCondition, updates interface{}) (*NodeCondition, error)
+	ById(id string) (*NodeCondition, error)
+	Delete(container *NodeCondition) error
+}
+
+func newNodeConditionClient(rancherClient *RancherClient) *NodeConditionClient {
+	return &NodeConditionClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *NodeConditionClient) Create(container *NodeCondition) (*NodeCondition, error) {
+	resp := &NodeCondition{}
+	err := c.rancherClient.doCreate(NODE_CONDITION_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *NodeConditionClient) Update(existing *NodeCondition, updates interface{}) (*NodeCondition, error) {
+	resp := &NodeCondition{}
+	err := c.rancherClient.doUpdate(NODE_CONDITION_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *NodeConditionClient) List(opts *ListOpts) (*NodeConditionCollection, error) {
+	resp := &NodeConditionCollection{}
+	err := c.rancherClient.doList(NODE_CONDITION_TYPE, opts, resp)
+	resp.client = c
+	return resp, err
+}
+
+func (cc *NodeConditionCollection) Next() (*NodeConditionCollection, error) {
+	if cc != nil && cc.Pagination != nil && cc.Pagination.Next != "" {
+		resp := &NodeConditionCollection{}
+		err := cc.client.rancherClient.doNext(cc.Pagination.Next, resp)
+		resp.client = cc.client
+		return resp, err
+	}
+	return nil, nil
+}
+
+func (c *NodeConditionClient) ById(id string) (*NodeCondition, error) {
+	resp := &NodeCondition{}
+	err := c.rancherClient.doById(NODE_CONDITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *NodeConditionClient) Delete(container *NodeCondition) error {
+	return c.rancherClient.doResourceDelete(NODE_CONDITION_TYPE, &container.Resource)
+}

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -254,7 +254,7 @@ func (nc *NodeController) syncNode(key string) (err error) {
 					condition.LastTransitionTime = util.Now()
 				}
 				condition.Status = types.ConditionStatusFalse
-				condition.Reason = string(types.NodeConditionReasonNodeDown)
+				condition.Reason = string(types.NodeConditionReasonManagerPodDown)
 				condition.Message = fmt.Sprintf("the manager pod %v is not running", pod.Name)
 			}
 			node.Status.Conditions[types.NodeConditionTypeReady] = condition

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -129,7 +129,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonNodeDown),
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonManagerPodDown),
 			},
 			MountPropagation: false,
 		},

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -97,15 +97,14 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus := map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusFalse, types.NodeConditionReasonNoMountPropagationSupport),
 			},
-			MountPropagation: false,
 		},
 		TestNode2: {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 		},
 	}
 	tc.expectNodeStatus = expectNodeStatus
@@ -129,15 +128,14 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonManagerPodDown),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonManagerPodDown),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusFalse, types.NodeConditionReasonNoMountPropagationSupport),
 			},
-			MountPropagation: false,
 		},
 		TestNode2: {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 		},
 	}
 	tc.expectNodeStatus = expectNodeStatus
@@ -161,15 +159,14 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusFalse, types.NodeConditionReasonNoMountPropagationSupport),
 			},
-			MountPropagation: false,
 		},
 		TestNode2: {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 		},
 	}
 	tc.expectNodeStatus = expectNodeStatus
@@ -213,9 +210,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: TestVolumeSize,
@@ -227,7 +224,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: 0,
@@ -275,9 +271,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: 0,
@@ -290,7 +286,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: 0,
@@ -341,9 +336,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeReady:            newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+				types.NodeConditionTypeMountPropagation: newNodeCondition(types.NodeConditionTypeMountPropagation, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				"changedId": {
 					StorageScheduled: 0,
@@ -356,7 +351,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			Conditions: map[types.NodeConditionType]types.Condition{
 				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
-			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
 					StorageScheduled: 0,
@@ -419,7 +413,6 @@ func (s *TestSuite) TestSyncNode(c *C) {
 				n.Status.Conditions[ctype] = condition
 			}
 			c.Assert(n.Status.Conditions, DeepEquals, tc.expectNodeStatus[nodeName].Conditions)
-			c.Assert(n.Status.MountPropagation, Equals, tc.expectNodeStatus[nodeName].MountPropagation)
 			if len(tc.expectNodeStatus[nodeName].DiskStatus) > 0 {
 				c.Assert(n.Status.DiskStatus, DeepEquals, tc.expectNodeStatus[nodeName].DiskStatus)
 			}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -87,8 +87,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 := newNode(TestNode1, TestNamespace, true, "")
-	node2 := newNode(TestNode2, TestNamespace, true, "")
+	node1 := newNode(TestNode1, TestNamespace, true, types.ConditionStatusUnknown, "")
+	node2 := newNode(TestNode2, TestNamespace, true, types.ConditionStatusUnknown, "")
 	nodes := map[string]*longhorn.Node{
 		TestNode1: node1,
 		TestNode2: node2,
@@ -96,11 +96,15 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.nodes = nodes
 	expectNodeStatus := map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 		},
 	}
@@ -115,8 +119,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 = newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
-	node2 = newNode(TestNode2, TestNamespace, true, types.NodeStateUp)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue, "")
 	nodes = map[string]*longhorn.Node{
 		TestNode1: node1,
 		TestNode2: node2,
@@ -124,11 +128,15 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.nodes = nodes
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateDown,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusFalse, types.NodeConditionReasonNodeDown),
+			},
 			MountPropagation: false,
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 		},
 	}
@@ -143,8 +151,8 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 = newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
-	node2 = newNode(TestNode2, TestNamespace, true, types.NodeStateDown)
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusFalse, "")
 	nodes = map[string]*longhorn.Node{
 		TestNode1: node1,
 		TestNode2: node2,
@@ -152,11 +160,15 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.nodes = nodes
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 		},
 	}
@@ -171,7 +183,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 = newNode(TestNode1, TestNamespace, true, "up")
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
 	node1.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -179,7 +191,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			State:            types.DiskStateSchedulable,
 		},
 	}
-	node2 = newNode(TestNode2, TestNamespace, true, "up")
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue, "")
 	node2.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -200,7 +212,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
@@ -210,7 +224,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			},
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
@@ -231,7 +247,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 = newNode(TestNode1, TestNamespace, true, "up")
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
 	node1.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -244,7 +260,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			State:            types.DiskStateSchedulable,
 		},
 	}
-	node2 = newNode(TestNode2, TestNamespace, true, "up")
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue, "")
 	node2.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -258,7 +274,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.nodes = nodes
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
@@ -269,7 +287,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			},
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
@@ -290,7 +310,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 		TestDaemon2: daemon2,
 	}
 	tc.pods = pods
-	node1 = newNode(TestNode1, TestNamespace, true, "up")
+	node1 = newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
 	node1.Spec.Disks = map[string]types.DiskSpec{
 		"changedId": {
 			Path:            TestDefaultDataPath,
@@ -306,7 +326,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			State:            types.DiskStateSchedulable,
 		},
 	}
-	node2 = newNode(TestNode2, TestNamespace, true, "up")
+	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue, "")
 	node2.Status.DiskStatus = map[string]types.DiskStatus{
 		TestDiskID1: {
 			StorageScheduled: 0,
@@ -320,7 +340,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 	tc.nodes = nodes
 	expectNodeStatus = map[string]types.NodeStatus{
 		TestNode1: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: true,
 			DiskStatus: map[string]types.DiskStatus{
 				"changedId": {
@@ -331,7 +353,9 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			},
 		},
 		TestNode2: {
-			State:            types.NodeStateUp,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, types.ConditionStatusTrue, ""),
+			},
 			MountPropagation: false,
 			DiskStatus: map[string]types.DiskStatus{
 				TestDiskID1: {
@@ -385,7 +409,16 @@ func (s *TestSuite) TestSyncNode(c *C) {
 
 			n, err := lhClient.LonghornV1alpha1().Nodes(TestNamespace).Get(node.Name, metav1.GetOptions{})
 			c.Assert(err, IsNil)
-			c.Assert(n.Status.State, Equals, tc.expectNodeStatus[nodeName].State)
+			for ctype, condition := range n.Status.Conditions {
+				if condition.Status != types.ConditionStatusUnknown {
+					c.Assert(condition.LastProbeTime, Not(Equals), "")
+				}
+				condition.LastProbeTime = ""
+				condition.LastTransitionTime = ""
+				condition.Message = ""
+				n.Status.Conditions[ctype] = condition
+			}
+			c.Assert(n.Status.Conditions, DeepEquals, tc.expectNodeStatus[nodeName].Conditions)
 			c.Assert(n.Status.MountPropagation, Equals, tc.expectNodeStatus[nodeName].MountPropagation)
 			if len(tc.expectNodeStatus[nodeName].DiskStatus) > 0 {
 				c.Assert(n.Status.DiskStatus, DeepEquals, tc.expectNodeStatus[nodeName].DiskStatus)

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -414,9 +414,9 @@ func newNode(name, namespace string, allowScheduling bool, status types.Conditio
 	}
 }
 
-func newNodeCondition(conditionType types.NodeConditionType, status types.ConditionStatus, reason string) types.Condition {
+func newNodeCondition(conditionType string, status types.ConditionStatus, reason string) types.Condition {
 	return types.Condition{
-		Type:    string(conditionType),
+		Type:    conditionType,
 		Status:  status,
 		Reason:  reason,
 		Message: "",
@@ -496,6 +496,9 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 				TestDiskID1: {
 					StorageAvailable: TestDiskAvailableSize,
 					StorageScheduled: 0,
+					Conditions: map[types.DiskConditionType]types.Condition{
+						types.DiskConditionTypeSchedulable: newNodeCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+					},
 				},
 			}
 			n, err := lhClient.Longhorn().Nodes(TestNamespace).Create(node)

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -389,7 +389,7 @@ func newDaemonPod(phase v1.PodPhase, name, namespace, nodeID, podIP string, moun
 	}
 }
 
-func newNode(name, namespace string, allowScheduling bool, status types.NodeState) *longhorn.Node {
+func newNode(name, namespace string, allowScheduling bool, status types.ConditionStatus, reason string) *longhorn.Node {
 	return &longhorn.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -407,8 +407,19 @@ func newNode(name, namespace string, allowScheduling bool, status types.NodeStat
 			},
 		},
 		Status: types.NodeStatus{
-			State: status,
+			Conditions: map[types.NodeConditionType]types.Condition{
+				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, status, reason),
+			},
 		},
+	}
+}
+
+func newNodeCondition(conditionType types.NodeConditionType, status types.ConditionStatus, reason string) types.Condition {
+	return types.Condition{
+		Type:    string(conditionType),
+		Status:  status,
+		Reason:  reason,
+		Message: "",
 	}
 }
 
@@ -417,8 +428,8 @@ func generateVolumeTestCaseTemplate() *VolumeTestCase {
 	engine := newEngineForVolume(volume)
 	replica1 := newReplicaForVolume(volume, engine, "", "")
 	replica2 := newReplicaForVolume(volume, engine, "", "")
-	node1 := newNode(TestNode1, TestNamespace, true, types.NodeStateUp)
-	node2 := newNode(TestNode2, TestNamespace, false, types.NodeStateUp)
+	node1 := newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue, "")
+	node2 := newNode(TestNode2, TestNamespace, false, types.ConditionStatusTrue, "")
 
 	return &VolumeTestCase{
 		volume: volume,

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -577,9 +577,6 @@ func (s *DataStore) CreateDefaultNode(name string) (*longhorn.Node, error) {
 			Name:            name,
 			AllowScheduling: true,
 		},
-		Status: types.NodeStatus{
-			State: types.NodeStateUp,
-		},
 	}
 	diskInfo, err := util.GetDiskInfo(types.DefaultLonghornDirectory)
 	if err != nil {
@@ -607,7 +604,11 @@ func (s *DataStore) GetNode(name string) (*longhorn.Node, error) {
 		}
 		return nil, err
 	}
-	return result.DeepCopy(), nil
+	node := result.DeepCopy()
+	if node.Status.Conditions == nil {
+		node.Status.Conditions = map[types.NodeConditionType]types.Condition{}
+	}
+	return node, nil
 }
 
 func (s *DataStore) UpdateNode(node *longhorn.Node) (*longhorn.Node, error) {
@@ -624,7 +625,11 @@ func (s *DataStore) ListNodes() (map[string]*longhorn.Node, error) {
 
 	for _, node := range nodeList {
 		// Cannot use cached object from lister
-		itemMap[node.Name] = node.DeepCopy()
+		result := node.DeepCopy()
+		if result.Status.Conditions == nil {
+			result.Status.Conditions = map[types.NodeConditionType]types.Condition{}
+		}
+		itemMap[node.Name] = result
 	}
 	return itemMap, nil
 }

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -190,7 +190,8 @@ func (m *VolumeManager) Create(name string, spec *types.VolumeSpec) (v *longhorn
 			return nil, fmt.Errorf("couldn't list nodes")
 		}
 		for _, node := range nodes {
-			if !node.Status.MountPropagation {
+			conditions := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeMountPropagation)
+			if conditions.Status != types.ConditionStatusTrue {
 				return nil, fmt.Errorf("cannot support BaseImage, node doesn't support mount propagation: %v", node)
 			}
 		}

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -128,7 +128,8 @@ func (rcs *ReplicaScheduler) getNodeInfo() (map[string]*longhorn.Node, error) {
 	}
 	scheduledNode := map[string]*longhorn.Node{}
 	for _, node := range nodeInfo {
-		if node != nil && node.DeletionTimestamp == nil && node.Status.State == types.NodeStateUp && node.Spec.AllowScheduling {
+		nodeReadyCondition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
+		if node != nil && node.DeletionTimestamp == nil && nodeReadyCondition.Status == types.ConditionStatusTrue && node.Spec.AllowScheduling {
 			scheduledNode[node.Name] = node
 		}
 	}

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -106,7 +106,8 @@ func filterNodeDisksForReplica(node *longhorn.Node, replica *longhorn.Replica, o
 	diskStatus := node.Status.DiskStatus
 	for fsid, disk := range disks {
 		status := diskStatus[fsid]
-		if !disk.AllowScheduling || status.State == types.DiskStateUnschedulable ||
+		diskCondition := types.GetDiskConditionFromStatus(status, types.DiskConditionTypeSchedulable)
+		if !disk.AllowScheduling || diskCondition.Status != types.ConditionStatusTrue ||
 			(replica.Spec.VolumeSize+status.StorageScheduled) > (disk.StorageMaximum-disk.StorageReserved)*(overProvisioningPercentage/100) ||
 			replica.Spec.VolumeSize > (status.StorageAvailable-disk.StorageMaximum*minimalAvailablePercentage/100)*overProvisioningPercentage/100 {
 			continue

--- a/scheduler/replica_scheduler_test.go
+++ b/scheduler/replica_scheduler_test.go
@@ -104,15 +104,15 @@ func newNode(name, namespace string, allowScheduling bool, status types.Conditio
 		},
 		Status: types.NodeStatus{
 			Conditions: map[types.NodeConditionType]types.Condition{
-				types.NodeConditionTypeReady: newNodeCondition(types.NodeConditionTypeReady, status),
+				types.NodeConditionTypeReady: newCondition(types.NodeConditionTypeReady, status),
 			},
 		},
 	}
 }
 
-func newNodeCondition(conditionType types.NodeConditionType, status types.ConditionStatus) types.Condition {
+func newCondition(conditionType string, status types.ConditionStatus) types.Condition {
 	return types.Condition{
-		Type:    string(conditionType),
+		Type:    conditionType,
 		Status:  status,
 		Reason:  "",
 		Message: "",
@@ -239,6 +239,9 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 	}
 	node2 := newNode(TestNode2, TestNamespace, false, types.ConditionStatusTrue)
@@ -318,12 +321,16 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
-			State:            types.DiskStateSchedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 		TestDiskID2: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
-			State:            types.DiskStateSchedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 	}
 	expectNode1 := newNode(TestNode1, TestNamespace, true, types.ConditionStatusTrue)
@@ -341,12 +348,16 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
-			State:            types.DiskStateSchedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 		TestDiskID2: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
-			State:            types.DiskStateUnschedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusFalse),
+			},
 		},
 	}
 	expectNode2 := newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue)
@@ -394,7 +405,9 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: 0,
 			StorageScheduled: 0,
-			State:            types.DiskStateSchedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 	}
 	node2 = newNode(TestNode2, TestNamespace, true, types.ConditionStatusTrue)
@@ -408,12 +421,16 @@ func (s *TestSuite) TestReplicaScheduler(c *C) {
 		TestDiskID1: {
 			StorageAvailable: 0,
 			StorageScheduled: TestDiskAvailableSize,
-			State:            types.DiskStateSchedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue),
+			},
 		},
 		TestDiskID2: {
 			StorageAvailable: TestDiskAvailableSize,
 			StorageScheduled: 0,
-			State:            types.DiskStateUnschedulable,
+			Conditions: map[types.DiskConditionType]types.Condition{
+				types.DiskConditionTypeSchedulable: newCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusFalse),
+			},
 		},
 	}
 	nodes = map[string]*longhorn.Node{

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -68,4 +68,10 @@ func (n *NodeStatus) DeepCopyInto(to *NodeStatus) {
 	for key, value := range n.DiskStatus {
 		to.DiskStatus[key] = value
 	}
+	if n.Conditions != nil {
+		to.Conditions = make(map[NodeConditionType]Condition)
+		for key, value := range n.Conditions {
+			to.Conditions[key] = value
+		}
+	}
 }

--- a/types/deepcopy.go
+++ b/types/deepcopy.go
@@ -75,3 +75,14 @@ func (n *NodeStatus) DeepCopyInto(to *NodeStatus) {
 		}
 	}
 }
+
+func (n *DiskStatus) DeepCopyInto(to *DiskStatus) {
+	*to = *n
+	if n.Conditions == nil {
+		return
+	}
+	to.Conditions = make(map[DiskConditionType]Condition)
+	for key, value := range n.Conditions {
+		to.Conditions[key] = value
+	}
+}

--- a/types/resource.go
+++ b/types/resource.go
@@ -191,17 +191,20 @@ type NodeSpec struct {
 	AllowScheduling bool                `json:"allowScheduling"`
 }
 
-type NodeState string
+type NodeConditionType string
 
 const (
-	NodeStateUp   = NodeState("up")
-	NodeStateDown = NodeState("down")
+	NodeConditionTypeReady = "Ready"
+)
+
+const (
+	NodeConditionReasonNodeDown = "NodeDown"
 )
 
 type NodeStatus struct {
-	State            NodeState             `json:"state"`
-	DiskStatus       map[string]DiskStatus `json:"diskStatus"`
-	MountPropagation bool                  `json:"mountPropagation"`
+	Conditions       map[NodeConditionType]Condition `json:"conditions"`
+	DiskStatus       map[string]DiskStatus           `json:"diskStatus"`
+	MountPropagation bool                            `json:"mountPropagation"`
 }
 
 type DiskSpec struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -198,7 +198,7 @@ const (
 )
 
 const (
-	NodeConditionReasonNodeDown = "NodeDown"
+	NodeConditionReasonManagerPodDown = "ManagerPodDown"
 )
 
 type NodeStatus struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -194,17 +194,18 @@ type NodeSpec struct {
 type NodeConditionType string
 
 const (
-	NodeConditionTypeReady = "Ready"
+	NodeConditionTypeReady            = "Ready"
+	NodeConditionTypeMountPropagation = "MountPropagation"
 )
 
 const (
-	NodeConditionReasonManagerPodDown = "ManagerPodDown"
+	NodeConditionReasonManagerPodDown            = "ManagerPodDown"
+	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
 )
 
 type NodeStatus struct {
-	Conditions       map[NodeConditionType]Condition `json:"conditions"`
-	DiskStatus       map[string]DiskStatus           `json:"diskStatus"`
-	MountPropagation bool                            `json:"mountPropagation"`
+	Conditions map[NodeConditionType]Condition `json:"conditions"`
+	DiskStatus map[string]DiskStatus           `json:"diskStatus"`
 }
 
 type DiskSpec struct {

--- a/types/resource.go
+++ b/types/resource.go
@@ -203,6 +203,16 @@ const (
 	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
 )
 
+type DiskConditionType string
+
+const (
+	DiskConditionTypeSchedulable = "Schedulable"
+)
+
+const (
+	DiskConditionReasonDiskPressure = "DiskPressure"
+)
+
 type NodeStatus struct {
 	Conditions map[NodeConditionType]Condition `json:"conditions"`
 	DiskStatus map[string]DiskStatus           `json:"diskStatus"`
@@ -215,15 +225,8 @@ type DiskSpec struct {
 	StorageReserved int64  `json:"storageReserved"`
 }
 
-type DiskState string
-
-const (
-	DiskStateSchedulable   = DiskState("schedulable")
-	DiskStateUnschedulable = DiskState("unschedulable")
-)
-
 type DiskStatus struct {
-	State            DiskState `json:"state"`
-	StorageAvailable int64     `json:"storageAvailable"`
-	StorageScheduled int64     `json:"storageScheduled"`
+	Conditions       map[DiskConditionType]Condition `json:"conditions"`
+	StorageAvailable int64                           `json:"storageAvailable"`
+	StorageScheduled int64                           `json:"storageScheduled"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -157,3 +157,11 @@ func GetNodeConditionFromStatus(status NodeStatus, conditionType NodeConditionTy
 	}
 	return condition
 }
+
+func GetDiskConditionFromStatus(status DiskStatus, conditionType DiskConditionType) Condition {
+	condition, exists := status.Conditions[conditionType]
+	if !exists {
+		condition = getUnknownCondition(string(conditionType))
+	}
+	return condition
+}

--- a/types/types.go
+++ b/types/types.go
@@ -137,10 +137,23 @@ func GetEngineImageChecksumName(image string) string {
 func GetVolumeConditionFromStatus(status VolumeStatus, conditionType VolumeConditionType) Condition {
 	condition, exists := status.Conditions[conditionType]
 	if !exists {
-		condition = Condition{
-			Type:   string(conditionType),
-			Status: ConditionStatusUnknown,
-		}
+		condition = getUnknownCondition(string(conditionType))
+	}
+	return condition
+}
+
+func getUnknownCondition(conditionType string) Condition {
+	condition := Condition{
+		Type:   string(conditionType),
+		Status: ConditionStatusUnknown,
+	}
+	return condition
+}
+
+func GetNodeConditionFromStatus(status NodeStatus, conditionType NodeConditionType) Condition {
+	condition, exists := status.Conditions[conditionType]
+	if !exists {
+		condition = getUnknownCondition(string(conditionType))
 	}
 	return condition
 }


### PR DESCRIPTION
- Change node.Status.State to node.Status.Condition
- Change node.Status.MountPropagaion to node.Status.Condition
- Change diskStatus.State to diskStatus.Condition
- Update node api and generate longhorn client.
- driver deployer will wait for node MountPropagation condition before deploy flexvolume or csi.

Fixed issue: https://github.com/rancher/longhorn/issues/168 and https://github.com/rancher/longhorn/issues/149 and https://github.com/rancher/longhorn/issues/164