### PR TITLE
controller: Temporarily stop updating the ProbeTime for the conditions

### DIFF
--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -240,7 +240,7 @@ func (nc *NodeController) syncNode(key string) (err error) {
 	for _, pod := range managerPods {
 		if pod.Spec.NodeName == node.Name {
 			condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
-			condition.LastProbeTime = util.Now()
+			//condition.LastProbeTime = util.Now()
 			switch pod.Status.Phase {
 			case v1.PodRunning:
 				if condition.Status != types.ConditionStatusTrue {
@@ -362,7 +362,7 @@ func (nc *NodeController) syncDiskStatus(node *longhorn.Node) error {
 		}
 
 		condition := types.GetDiskConditionFromStatus(diskStatus, types.DiskConditionTypeSchedulable)
-		condition.LastProbeTime = util.Now()
+		//condition.LastProbeTime = util.Now()
 		// check disk pressure
 		if diskStatus.StorageAvailable <= disk.StorageMaximum*minimalAvailablePercentage/100 {
 			if condition.Status != types.ConditionStatusFalse {
@@ -429,7 +429,7 @@ func (nc *NodeController) syncNodeStatus(pod *v1.Pod, node *longhorn.Node) error
 				condition.Reason = ""
 				condition.Message = ""
 			}
-			condition.LastProbeTime = util.Now()
+			//condition.LastProbeTime = util.Now()
 			break
 		}
 	}

--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -421,9 +421,11 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			n, err := lhClient.LonghornV1alpha1().Nodes(TestNamespace).Get(node.Name, metav1.GetOptions{})
 			c.Assert(err, IsNil)
 			for ctype, condition := range n.Status.Conditions {
-				if condition.Status != types.ConditionStatusUnknown {
-					c.Assert(condition.LastProbeTime, Not(Equals), "")
-				}
+				/*
+					if condition.Status != types.ConditionStatusUnknown {
+						c.Assert(condition.LastProbeTime, Not(Equals), "")
+					}
+				*/
 				condition.LastProbeTime = ""
 				condition.LastTransitionTime = ""
 				condition.Message = ""
@@ -435,7 +437,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 				for fsid, diskStatus := range diskConditions {
 					for ctype, condition := range diskStatus.Conditions {
 						if condition.Status != types.ConditionStatusUnknown {
-							c.Assert(condition.LastProbeTime, Not(Equals), "")
+							//c.Assert(condition.LastProbeTime, Not(Equals), "")
 							c.Assert(condition.LastTransitionTime, Not(Equals), "")
 						}
 						condition.LastProbeTime = ""

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -540,7 +540,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 				condition.Status = types.ConditionStatusFalse
 				condition.LastTransitionTime = util.Now()
 			}
-			condition.LastProbeTime = util.Now()
+			//condition.LastProbeTime = util.Now()
 			condition.Reason = types.VolumeConditionReasonReplicaSchedulingFailure
 			v.Status.Conditions[types.VolumeConditionTypeScheduled] = condition
 			allScheduled = false
@@ -563,7 +563,7 @@ func (vc *VolumeController) ReconcileVolumeState(v *longhorn.Volume, e *longhorn
 			condition.Message = ""
 			condition.LastTransitionTime = util.Now()
 		}
-		condition.LastProbeTime = util.Now()
+		//condition.LastProbeTime = util.Now()
 		v.Status.Conditions[types.VolumeConditionTypeScheduled] = condition
 	}
 

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -544,9 +544,11 @@ func (s *TestSuite) runTestCases(c *C, testCases map[string]*VolumeTestCase) {
 		c.Assert(retV.Spec, DeepEquals, tc.expectVolume.Spec)
 		// mask timestamps
 		for ctype, condition := range retV.Status.Conditions {
-			if ctype == types.VolumeConditionTypeScheduled {
-				c.Assert(condition.LastProbeTime, Not(Equals), "")
-			}
+			/*
+				if ctype == types.VolumeConditionTypeScheduled {
+					c.Assert(condition.LastProbeTime, Not(Equals), "")
+				}
+			*/
 			condition.LastProbeTime = ""
 			condition.LastTransitionTime = ""
 			retV.Status.Conditions[ctype] = condition


### PR DESCRIPTION
It caused too many conflicts for now. We will dig more later. Temporarily stop
updating the ProbeTime