### PR TITLE
controller: Add Ready State for disk Status

### DIFF
--- a/controller/node_controller_test.go
+++ b/controller/node_controller_test.go
@@ -220,6 +220,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 					StorageScheduled: TestVolumeSize,
 					Conditions: map[types.DiskConditionType]types.Condition{
 						types.DiskConditionTypeSchedulable: newNodeCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusFalse, string(types.DiskConditionReasonDiskPressure)),
+						types.DiskConditionTypeReady:       newNodeCondition(types.DiskConditionTypeReady, types.ConditionStatusTrue, ""),
 					},
 				},
 			},
@@ -291,6 +292,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 					StorageAvailable: 0,
 					Conditions: map[types.DiskConditionType]types.Condition{
 						types.DiskConditionTypeSchedulable: newNodeCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusFalse, string(types.DiskConditionReasonDiskPressure)),
+						types.DiskConditionTypeReady:       newNodeCondition(types.DiskConditionTypeReady, types.ConditionStatusTrue, ""),
 					},
 				},
 			},
@@ -333,6 +335,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 			StorageAvailable: 0,
 			Conditions: map[types.DiskConditionType]types.Condition{
 				types.DiskConditionTypeSchedulable: newNodeCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusTrue, ""),
+				types.DiskConditionTypeReady:       newNodeCondition(types.DiskConditionTypeReady, types.ConditionStatusTrue, ""),
 			},
 		},
 	}
@@ -360,6 +363,7 @@ func (s *TestSuite) TestSyncNode(c *C) {
 					StorageAvailable: 0,
 					Conditions: map[types.DiskConditionType]types.Condition{
 						types.DiskConditionTypeSchedulable: newNodeCondition(types.DiskConditionTypeSchedulable, types.ConditionStatusFalse, string(types.DiskConditionReasonDiskPressure)),
+						types.DiskConditionTypeReady:       newNodeCondition(types.DiskConditionTypeReady, types.ConditionStatusFalse, string(types.DiskConditionReasonDiskFilesystemChanged)),
 					},
 				},
 			},

--- a/scheduler/replica_scheduler.go
+++ b/scheduler/replica_scheduler.go
@@ -152,7 +152,8 @@ func (rcs *ReplicaScheduler) scheduleReplicaToDisk(replica *longhorn.Replica, di
 }
 
 func (rcs *ReplicaScheduler) IsSchedulableToDisk(size int64, info *DiskSchedulingInfo) bool {
-	return (size+info.StorageScheduled) <= (info.StorageMaximum-info.StorageReserved)*(info.OverProvisioningPercentage/100) &&
+	return info.StorageMaximum > 0 && info.StorageAvailable > 0 &&
+		(size+info.StorageScheduled) <= (info.StorageMaximum-info.StorageReserved)*(info.OverProvisioningPercentage/100) &&
 		size <= (info.StorageAvailable-info.StorageMaximum*info.MinimalAvailablePercentage/100)*info.OverProvisioningPercentage/100
 }
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -207,10 +207,13 @@ type DiskConditionType string
 
 const (
 	DiskConditionTypeSchedulable = "Schedulable"
+	DiskConditionTypeReady       = "Ready"
 )
 
 const (
-	DiskConditionReasonDiskPressure = "DiskPressure"
+	DiskConditionReasonDiskPressure          = "DiskPressure"
+	DiskConditionReasonDiskFilesystemChanged = "DiskFilesystemChanged"
+	DiskConditionReasonNoDiskInfo            = "NoDiskInfo"
 )
 
 type NodeStatus struct {


### PR DESCRIPTION
Add `ready` state condition for disk status, when disk is not ready, e.g. umount the disk, `Schdulable` condition should be `Unschedulable` too.

Fixed issue: https://github.com/rancher/longhorn/issues/189