### PR TITLE
Deal with physical node remove

### DIFF
--- a/api/node.go
+++ b/api/node.go
@@ -108,3 +108,12 @@ func (s *Server) DiskUpdate(rw http.ResponseWriter, req *http.Request) error {
 	apiContext.Write(toNodeResource(unode, nodeIPMap[id], apiContext))
 	return nil
 }
+
+func (s *Server) NodeDelete(rw http.ResponseWriter, req *http.Request) error {
+	id := mux.Vars(req)["name"]
+	if err := s.m.DeleteNode(id); err != nil {
+		return errors.Wrap(err, "unable to delete node")
+	}
+
+	return nil
+}

--- a/api/router.go
+++ b/api/router.go
@@ -101,6 +101,7 @@ func NewRouter(s *Server) *mux.Router {
 	r.Methods("GET").Path("/v1/nodes").Handler(f(schemas, s.NodeList))
 	r.Methods("GET").Path("/v1/nodes/{name}").Handler(f(schemas, s.NodeGet))
 	r.Methods("PUT").Path("/v1/nodes/{name}").Handler(f(schemas, s.NodeUpdate))
+	r.Methods("DELETE").Path("/v1/nodes/{name}").Handler(f(schemas, s.NodeDelete))
 	nodeActions := map[string]func(http.ResponseWriter, *http.Request) error{
 		"diskUpdate": s.fwd.Handler(OwnerIDFromNode(s.m), s.DiskUpdate),
 	}

--- a/controller/controller_manager.go
+++ b/controller/controller_manager.go
@@ -67,6 +67,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 	settingInformer := lhInformerFactory.Longhorn().V1alpha1().Settings()
 
 	podInformer := kubeInformerFactory.Core().V1().Pods()
+	kubeNodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	jobInformer := kubeInformerFactory.Batch().V1().Jobs()
 	cronJobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	daemonSetInformer := kubeInformerFactory.Apps().V1beta2().DaemonSets()
@@ -91,7 +92,7 @@ func StartControllers(stopCh chan struct{}, controllerID, serviceAccount, manage
 		engineImageInformer, volumeInformer, daemonSetInformer,
 		kubeClient, namespace, controllerID)
 	nc := NewNodeController(ds, scheme,
-		nodeInformer, settingInformer, podInformer, replicaInformer,
+		nodeInformer, settingInformer, podInformer, replicaInformer, kubeNodeInformer,
 		kubeClient, namespace, controllerID)
 	ws := NewWebsocketController(volumeInformer, engineInformer, replicaInformer,
 		settingInformer, engineImageInformer, nodeInformer)

--- a/datastore/kubernetes.go
+++ b/datastore/kubernetes.go
@@ -165,3 +165,7 @@ func (s *DataStore) ListEvents() ([]*corev1.Event, error) {
 	}
 	return eList, nil
 }
+
+func (s *DataStore) GetKubernetesNode(name string) (*corev1.Node, error) {
+	return s.kubeClient.CoreV1().Nodes().Get(name, metav1.GetOptions{})
+}

--- a/types/resource.go
+++ b/types/resource.go
@@ -200,6 +200,7 @@ const (
 
 const (
 	NodeConditionReasonManagerPodDown            = "ManagerPodDown"
+	NodeConditionReasonKubernetesNodeDown        = "KubernetesNodeDown"
 	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
 )
 

--- a/types/resource.go
+++ b/types/resource.go
@@ -200,7 +200,10 @@ const (
 
 const (
 	NodeConditionReasonManagerPodDown            = "ManagerPodDown"
+	NodeConditionReasonManagerPodMissing         = "ManagerPodMissing"
 	NodeConditionReasonKubernetesNodeDown        = "KubernetesNodeDown"
+	NodeConditionReasonKubernetesNodeNotReady    = "KubernetesNodeNotReady"
+	NodeConditionReasonKubernetesNodePressure    = "KubernetesNodePressure"
 	NodeConditionReasonNoMountPropagationSupport = "NoMountPropagationSupport"
 )
 


### PR DESCRIPTION
We need to support user remove physical node from cluster. Generally when user delete physical node: 
- Change node status to `Down`
- Export Node delete API for UI, user could delete the node without longhorn-manager running on it.
- If volume has attached to the node which has been deleted, Detach it(replica on the removed node is remained for now and user need to delete this replica manually before attach to other node).
- If EngineImage is controlled by the node which has been deleted, change it to another node.