### PR TITLE
deploy: Keep the engine at v0.3.0

### DIFF
--- a/deploy/02-components/01-manager.yaml
+++ b/deploy/02-components/01-manager.yaml
@@ -25,7 +25,7 @@ spec:
         - -d
         - daemon
         - --engine-image
-        - rancher/longhorn-engine:v0.3.1-rc1
+        - rancher/longhorn-engine:v0.3.0
         - --manager-image
         - rancher/longhorn-manager:v0.3.1-rc1
         - --service-account


### PR DESCRIPTION
There is no function change from v0.3.0 to v0.3.1-rc1. Don't want to trigger
unnecessary upgrade process for the engine.