### PR TITLE
controller: no longer require S3 endpoint if we're using AWS S3

### DIFF
--- a/controller/replica_controller.go
+++ b/controller/replica_controller.go
@@ -467,8 +467,12 @@ func (rc *ReplicaController) CreatePodSpec(obj interface{}) (*v1.Pod, error) {
 			return nil, err
 		}
 		if secret.Value != "" {
-			err := util.ConfigEnvWithCredential(r.Spec.RestoreFrom, secret.Value, &pod.Spec.Containers[0])
+			credentials, err := rc.ds.GetCredentialFromSecret(secret.Value)
 			if err != nil {
+				return nil, err
+			}
+			hasEndpoint := (credentials[types.AWSEndPoint] != "")
+			if err := util.ConfigEnvWithCredential(r.Spec.RestoreFrom, secret.Value, hasEndpoint, &pod.Spec.Containers[0]); err != nil {
 				return nil, err
 			}
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -356,7 +356,7 @@ func ConfigBackupCredential(backupTarget string, credential map[string]string) e
 	return nil
 }
 
-func ConfigEnvWithCredential(backupTarget string, credentialSecret string, container *v1.Container) error {
+func ConfigEnvWithCredential(backupTarget string, credentialSecret string, hasEndpoint bool, container *v1.Container) error {
 	backupType, err := CheckBackupType(backupTarget)
 	if err != nil {
 		return err
@@ -374,7 +374,7 @@ func ConfigEnvWithCredential(backupTarget string, credentialSecret string, conta
 			},
 		}
 		container.Env = append(container.Env, accessKeyEnv)
-		secreKeyEnv := v1.EnvVar{
+		secretKeyEnv := v1.EnvVar{
 			Name: AWSSecretKey,
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
@@ -385,19 +385,21 @@ func ConfigEnvWithCredential(backupTarget string, credentialSecret string, conta
 				},
 			},
 		}
-		container.Env = append(container.Env, secreKeyEnv)
-		endpointEnv := v1.EnvVar{
-			Name: AWSEndPoint,
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: credentialSecret,
+		container.Env = append(container.Env, secretKeyEnv)
+		if hasEndpoint {
+			endpointEnv := v1.EnvVar{
+				Name: AWSEndPoint,
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: credentialSecret,
+						},
+						Key: AWSEndPoint,
 					},
-					Key: AWSEndPoint,
 				},
-			},
+			}
+			container.Env = append(container.Env, endpointEnv)
 		}
-		container.Env = append(container.Env, endpointEnv)
 	}
 	return nil
 }


### PR DESCRIPTION
Before this commit, we need following configuration in the secret to use AWS S3:

```
AWS_ENDPOINTS: <base64 encoded AWS endpoint> #s3.<region>.amazonaws.com
```

Noticed that we've made a typo here, it should be `AWS_ENDPOINT` instead of
`AWS_ENDPOINTS`. Though change it will break backward compatiability. We will do
it later.