### PR TITLE
controller: Fix regression caused by mark the replicas on down nodes as failed when attaching

### DIFF
--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -734,7 +734,9 @@ func (s *DataStore) IsNodeDownOrDeleted(name string) (bool, error) {
 		return false, err
 	}
 	cond := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
-	if cond.Status == types.ConditionStatusFalse {
+	if cond.Status == types.ConditionStatusFalse &&
+		(cond.Reason == string(types.NodeConditionReasonKubernetesNodeDown) ||
+			cond.Reason == string(types.NodeConditionReasonKubernetesNodeNotReady)) {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
The node down reason for manager pod down/missing can due to the restart of
manager, which shouldn't affect the running volumes at all.

Fixes https://github.com/rancher/longhorn/issues/390