### PR TITLE
Revert "deploy: Scale UI to 3 replicas for HA"

### DIFF
--- a/deploy/install/02-components/03-ui.yaml
+++ b/deploy/install/02-components/03-ui.yaml
@@ -6,7 +6,7 @@ metadata:
   name: longhorn-ui
   namespace: longhorn-system
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: longhorn-ui


### PR DESCRIPTION
This reverts commit b04a3b27ba921569b0f95e7c4668690f8b27daf7.

User can manually adjust the UI replica numbers.

Nginx doesn't make it better if one UI lost.