### PR TITLE
Support Bundle functionality split to 3 requests

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -168,6 +168,12 @@ type Event struct {
 	EventType string `json:"eventType"`
 }
 
+type SupportBundle struct {
+	client.Resource
+	BundleName string `json:"name"`
+	NodeID     string `json:"hostId"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -199,6 +205,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("diskCondition", types.Condition{})
 
 	schemas.AddType("event", Event{})
+	schemas.AddType("supportBundle", SupportBundle{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))
@@ -735,4 +742,16 @@ func toEventCollection(eventList *v1.EventList) *client.GenericCollection {
 		data = append(data, toEventResource(event))
 	}
 	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "event"}}
+}
+
+//Support Bundle Resource
+func toSBResource(nodeID string, bundleFileName string) *SupportBundle {
+	return &SupportBundle{
+		Resource: client.Resource{
+			Id:   nodeID,
+			Type: "supportbundle",
+		},
+		NodeID:     nodeID,
+		BundleName: bundleFileName,
+	}
 }

--- a/api/router.go
+++ b/api/router.go
@@ -120,7 +120,11 @@ func NewRouter(s *Server) *mux.Router {
 
 	r.Methods("Get").Path("/v1/events").Handler(f(schemas, s.EventList))
 
-	r.Methods("Get").Path("/v1/supportbundle").Handler(f(schemas, s.GenerateSupportBundle))
+	r.Methods("POST").Path("/v1/supportbundles").Handler(f(schemas, s.InitiateSupportBundle))
+	r.Methods("GET").Path("/v1/supportbundles/{name}").Handler(f(schemas,
+		s.fwd.Handler(OwnerIDFromNode(s.m), s.CheckSupportBundle)))
+	r.Methods("POST").Path("/v1/supportbundles/{name}").Queries("action", "download").Handler(f(schemas,
+		s.fwd.Handler(OwnerIDFromNode(s.m), s.GetSupportBundle)))
 
 	settingListStream := NewStreamHandlerFunc("settings", s.wsc.NewWatcher("setting"), s.settingList)
 	r.Path("/v1/ws/settings").Handler(f(schemas, settingListStream))


### PR DESCRIPTION
Earlier the support bundle download was a single GET request and it was a blocking call where the request was forwarded to the manager and when the download completes it returns the compressed zip file back to the caller. This was causing timeout if the content is huge.
In order to fix this issue, the request is split into 3 requests:
1. POST request to initiate a support bundle download and the backend returns the nodeid of the manager that's performing this operation
2. GET request to check the status of download. This returns true or false based on the progress of the download.
3. POST request to download the compressed file.

Git Commit ID: a52cea4f660e26fd52e384e86031cf49d588ae92
After Review Comments: d29eac636d9602764cf03647062fa73d32699cb9