### PR TITLE
Check for update after getting result from lister

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,12 +4,14 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/controller"
-	"testing"
 
 	. "gopkg.in/check.v1"
 )
@@ -66,6 +68,7 @@ type TestSuite struct {
 var _ = Suite(&TestSuite{})
 
 func (s *TestSuite) SetUpTest(c *C) {
+	logrus.SetLevel(logrus.DebugLevel)
 }
 
 func getKey(obj interface{}, c *C) string {

--- a/controller/volume_controller.go
+++ b/controller/volume_controller.go
@@ -1326,30 +1326,6 @@ func (vc *VolumeController) createAndStartMatchingReplicas(v *longhorn.Volume,
 		pathToNewRs[path] = nr
 		rs[nr.Name] = nr
 	}
-
-	// WORKAROUND: The immedidate read after multiple object's write seems
-	// can fail. See https://github.com/rancher/longhorn/issues/133
-	found := false
-	for i := 0; i < RetryCounts; i++ {
-		tmprs, err := vc.ds.ListVolumeReplicas(v.Name)
-		if err != nil {
-			return errors.Wrapf(err, "volume %v: cannot check matching replicas", v.Name)
-		}
-		if len(tmprs) == len(rs) {
-			found = true
-			break
-		}
-		if len(tmprs) > len(rs) {
-			logrus.Errorf("BUG: volume %v: new Replicas are more than expected!", v.Name)
-			break
-		}
-		logrus.Debugf("volume %v: New replicas wasn't showing up, retrying", v.Name)
-		time.Sleep(RetryInterval)
-	}
-	if !found {
-		return fmt.Errorf("volume %v: cannot verify the existance of newly created replicas", v.Name)
-	}
-
 	return nil
 }
 

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -94,6 +94,10 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	var tc *VolumeTestCase
 	testCases := map[string]*VolumeTestCase{}
 
+	// We have to skip lister check for unit tests
+	// Because the changes written through the API won't be reflected in the listers
+	datastore.SkipListerCheck = true
+
 	// normal volume creation
 	tc = generateVolumeTestCaseTemplate()
 	// default replica and engine objects will be copied by copyCurrentToExpect

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -17,6 +17,10 @@ import (
 	lhlisters "github.com/rancher/longhorn-manager/k8s/pkg/client/listers/longhorn/v1alpha1"
 )
 
+var (
+	SkipListerCheck = false
+)
+
 type DataStore struct {
 	namespace string
 

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -1068,11 +1068,11 @@ func (s *DataStore) UpdateVolumeAndOwner(v *longhorn.Volume) (*longhorn.Volume, 
 func (s *DataStore) ResetEngineMonitoringStatus(e *longhorn.Engine) (*longhorn.Engine, error) {
 	e.Status.Endpoint = ""
 	e.Status.ReplicaModeMap = nil
-	e, err := s.UpdateEngine(e)
+	ret, err := s.UpdateEngine(e)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to reste engine status for %v", e.Name)
+		return nil, errors.Wrapf(err, "failed to reset engine status for %v", e.Name)
 	}
-	return e, nil
+	return ret, nil
 }
 
 func (s *DataStore) DeleteNode(name string) error {


### PR DESCRIPTION
Kubernetes listers have built-in cache mechanism, so it's much faster than query the API server directly. But they cannot guarantee the order of the sequence since we create/update the object in the API, and it will take some time for the lister's cache to reflect that change.

For example:
1. Create an object X
2. Get the object X using lister

The second step can still return NotFound since the lister's cache may not be updated yet.

This won't happen most of the time, but still caused many troubles for Longhorn who relies on the lister. This happened more frequently on K3S since K3S is using SQLite instead of ETCD in the backend for the API server, so the event trigger for updating the lister's cache may not be as fast as ETCD's watch mechanism.

We've tried to switch to use API directly for everything, but it's too slow.

In the end, we implemented this additional check after create/update an object, and make sure lister at least has the new version in the cache.

Fixes https://github.com/rancher/longhorn/issues/133
Fixes https://github.com/rancher/longhorn/issues/436
Fixes https://github.com/rancher/longhorn/issues/499