### PR TITLE
New Support Bundle Design

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -168,6 +168,18 @@ type Event struct {
 	EventType string `json:"eventType"`
 }
 
+type SupportBundle struct {
+	client.Resource
+	NodeID       string                     `json:"nodeID"`
+	State        manager.BundleState        `json:"state"`
+	Name         string                     `json:"name"`
+	ErrorMessage manager.BundleErrorMessage `json:"errorMessage"`
+}
+
+type SupportBundleQueryInput struct {
+	Name string `json:"name"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -199,6 +211,8 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("diskCondition", types.Condition{})
 
 	schemas.AddType("event", Event{})
+	schemas.AddType("supportBundle", SupportBundle{})
+	schemas.AddType("supportBundleQueryInput", SupportBundleQueryInput{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))
@@ -735,4 +749,18 @@ func toEventCollection(eventList *v1.EventList) *client.GenericCollection {
 		data = append(data, toEventResource(event))
 	}
 	return &client.GenericCollection{Data: data, Collection: client.Collection{ResourceType: "event"}}
+}
+
+//Support Bundle Resource
+func toSupportBundleResource(nodeID string, sb *manager.SupportBundle) *SupportBundle {
+	return &SupportBundle{
+		Resource: client.Resource{
+			Id:   nodeID,
+			Type: "supportbundle",
+		},
+		NodeID:       nodeID,
+		State:        sb.State,
+		Name:         sb.Filename,
+		ErrorMessage: sb.Error,
+	}
 }

--- a/api/router.go
+++ b/api/router.go
@@ -120,7 +120,11 @@ func NewRouter(s *Server) *mux.Router {
 
 	r.Methods("Get").Path("/v1/events").Handler(f(schemas, s.EventList))
 
-	r.Methods("Get").Path("/v1/supportbundle").Handler(f(schemas, s.GenerateSupportBundle))
+	r.Methods("POST").Path("/v1/supportbundles").Handler(f(schemas, s.InitiateSupportBundle))
+	r.Methods("GET").Path("/v1/supportbundles/{name}").Handler(f(schemas,
+		s.fwd.Handler(OwnerIDFromNode(s.m), s.QuerySupportBundle)))
+	r.Methods("POST").Path("/v1/supportbundles/{name}").Queries("action", "download").Handler(f(schemas,
+		s.fwd.Handler(OwnerIDFromNode(s.m), s.DownloadSupportBundle)))
 
 	settingListStream := NewStreamHandlerFunc("settings", s.wsc.NewWatcher("setting"), s.settingList)
 	r.Path("/v1/ws/settings").Handler(f(schemas, settingListStream))

--- a/manager/volume.go
+++ b/manager/volume.go
@@ -2,8 +2,12 @@ package manager
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -17,10 +21,40 @@ import (
 	longhorn "github.com/rancher/longhorn-manager/k8s/pkg/apis/longhorn/v1alpha1"
 )
 
+type BundleState string
+
+const (
+	BundleStateInProgress  = BundleState("InProgress")
+	BundleReadyForDownload = BundleState("ReadyForDownload")
+	BundleStateError       = BundleState("Error")
+)
+
+type BundleErrorMessage string
+
+const (
+	BundleMkdirFailed = BundleErrorMessage("Failed to create bundle file directory")
+	BundleZipFailed   = BundleErrorMessage("Failed to compress the support bundle files")
+	BundleOpenFailed  = BundleErrorMessage("Failed to open the compressed bundle file")
+	BundleStatFailed  = BundleErrorMessage("Failed to compute the size of the compressed bundle file")
+)
+
+type SupportBundle struct {
+	State      BundleState
+	Size       int64
+	Error      BundleErrorMessage
+	Filename   string
+	createTime time.Time
+}
+
+func NewSupportBundle(state BundleState, filename string) *SupportBundle {
+	return &SupportBundle{State: state, Filename: filename}
+}
+
 type VolumeManager struct {
 	ds *datastore.DataStore
 
 	currentNodeID string
+	sb            *SupportBundle
 }
 
 func NewVolumeManager(currentNodeID string, ds *datastore.DataStore) *VolumeManager {
@@ -33,6 +67,33 @@ func NewVolumeManager(currentNodeID string, ds *datastore.DataStore) *VolumeMana
 
 func (m *VolumeManager) GetCurrentNodeID() string {
 	return m.currentNodeID
+}
+
+func (m *VolumeManager) GetSupportBundle(filename string) (*SupportBundle, error) {
+	if m.sb.Filename != filename {
+		return nil, errors.Errorf("cannot find the bundle file - %s", filename)
+	}
+
+	return m.sb, nil
+}
+
+func (m *VolumeManager) DeleteSupportBundle() {
+	os.Remove(filepath.Join("/tmp", m.sb.Filename))
+	m.sb = nil
+}
+
+func (m *VolumeManager) GetBundleFileHandler() (io.ReadCloser, error) {
+	f, err := os.Open(filepath.Join("/tmp", m.sb.Filename))
+	if err != nil {
+		m.sb.Error = BundleOpenFailed
+		return nil, errors.Wrapf(err, "unable to open the bundle file")
+	}
+	return f, nil
+}
+
+func (m *VolumeManager) isPreviousSupportBundleExpired() bool {
+	t := time.Now()
+	return t.Sub(m.sb.createTime).Hours() >= 1
 }
 
 func (m *VolumeManager) Node2APIAddress(nodeID string) (string, error) {


### PR DESCRIPTION
Earlier the support bundle download was a single GET request and it was a blocking call where the request was forwarded to the manager and when the download completes it returns the compressed zip file back to the caller. This was causing timeout if the content is huge.
The detailed design of this feature is described here: 
Support bundle could be obtained using 3 HTTP requests:
1. POST request to Initiate Support Bundle feature
2. GET request to Query the state of the previous request
3. POST request to Download the Support Bundle file

Commit ID: 918b224d68cb62dc94c81dba48c595533e2d2cc0
After Review: ab5404a26bf8748a9b599db2b53c33998120329a