### PR TITLE
Enforcing Support Bundle Description

### DIFF
--- a/api/misc.go
+++ b/api/misc.go
@@ -33,8 +33,13 @@ func (s *Server) eventList(apiContext *api.ApiContext) (*client.GenericCollectio
 
 func (s *Server) InitiateSupportBundle(w http.ResponseWriter, req *http.Request) error {
 	var sb *manager.SupportBundle
+	var supportBundleInput SupportBundleInitateInput
+
 	apiContext := api.GetApiContext(req)
-	sb, err := s.m.InitSupportBundle()
+	if err := apiContext.Read(&supportBundleInput); err != nil {
+		return err
+	}
+	sb, err := s.m.InitSupportBundle(supportBundleInput.IssueURL, supportBundleInput.Description)
 	if err != nil {
 		return errors.Errorf("unable to initiate Support Bundle Download:%v", err)
 	}

--- a/api/model.go
+++ b/api/model.go
@@ -180,6 +180,11 @@ type SupportBundleQueryInput struct {
 	Name string `json:"name"`
 }
 
+type SupportBundleInitateInput struct {
+	IssueURL    string `json:"issueURL"`
+	Description string `json:"description"`
+}
+
 func NewSchema() *client.Schemas {
 	schemas := &client.Schemas{}
 
@@ -213,6 +218,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("event", Event{})
 	schemas.AddType("supportBundle", SupportBundle{})
 	schemas.AddType("supportBundleQueryInput", SupportBundleQueryInput{})
+	schemas.AddType("supportBundleInitateInput", SupportBundleInitateInput{})
 
 	volumeSchema(schemas.AddType("volume", Volume{}))
 	backupVolumeSchema(schemas.AddType("backupVolume", BackupVolume{}))

--- a/manager/misc.go
+++ b/manager/misc.go
@@ -32,6 +32,8 @@ type BundleMeta struct {
 	KubernetesVersion     string `json:"kubernetesVersion"`
 	LonghornNamespaceUUID string `json:"longhornNamspaceUUID"`
 	BundleCreatedAt       string `json:"bundleCreatedAt"`
+	IssueURL              string `json:"issueURL"`
+	IssueDescription      string `json:"issueDescription"`
 }
 
 // GenerateSupportBundle covers:
@@ -56,7 +58,7 @@ type BundleMeta struct {
 //     |- <container1>.log
 //     |- ...
 // The bundle would be compressed to a zip file for download.
-func (m *VolumeManager) GenerateSupportBundle() (*SupportBundle, error) {
+func (m *VolumeManager) GenerateSupportBundle(issueURL string, description string) (*SupportBundle, error) {
 	namespace, err := m.ds.GetLonghornNamespace()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get longhorn namespace")
@@ -71,6 +73,8 @@ func (m *VolumeManager) GenerateSupportBundle() (*SupportBundle, error) {
 		KubernetesVersion:     kubeVersion.GitVersion,
 		LonghornNamespaceUUID: string(namespace.UID),
 		BundleCreatedAt:       util.Now(),
+		IssueURL:              issueURL,
+		IssueDescription:      description,
 	}
 
 	bundleName := "longhorn-support-bundle_" + bundleMeta.LonghornNamespaceUUID + "_" +
@@ -274,7 +278,7 @@ func streamLogToFile(logStream io.ReadCloser, path string, errLog io.Writer) {
 	}
 }
 
-func (m *VolumeManager) InitSupportBundle() (*SupportBundle, error) {
+func (m *VolumeManager) InitSupportBundle(issueURL string, description string) (*SupportBundle, error) {
 	if m.sb != nil {
 		if m.sb.State == BundleStateInProgress {
 			return nil, errors.Errorf("longhorn-manager is busy processing another support bundle request")
@@ -286,7 +290,7 @@ func (m *VolumeManager) InitSupportBundle() (*SupportBundle, error) {
 		m.DeleteSupportBundle()
 	}
 
-	sb, err := m.GenerateSupportBundle()
+	sb, err := m.GenerateSupportBundle(issueURL, description)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit entails the Support Bundle request to contain the GitHub issue URL and the issue description which is read by the Initiate API and eventually written into metadata.yaml
As a result when the user sends the compressed zip file, all the information he entered in UI will be part of metadata.yaml.