### PR TITLE
manager: Initiate support bundle now clean existing request automatically

### DIFF
--- a/api/misc.go
+++ b/api/misc.go
@@ -43,9 +43,7 @@ func (s *Server) InitiateSupportBundle(w http.ResponseWriter, req *http.Request)
 	if err != nil {
 		return errors.Errorf("unable to initiate Support Bundle Download:%v", err)
 	}
-	if sb != nil {
-		apiContext.Write(toSupportBundleResource(s.m.GetCurrentNodeID(), sb))
-	}
+	apiContext.Write(toSupportBundleResource(s.m.GetCurrentNodeID(), sb))
 	return nil
 }
 


### PR DESCRIPTION
Make it easier for UI to repeat the request if needed.

The downside is if multiple users request the bundle at the same time,
some of the requests will be denied and the user would need to retry.