### PR TITLE
Update EngineSpec OwnerID when the existing OwnerID goes down

### DIFF
--- a/controller/engine_image_controller.go
+++ b/controller/engine_image_controller.go
@@ -209,7 +209,15 @@ func (ic *EngineImageController) syncEngineImage(key string) (err error) {
 		return err
 	}
 
-	if engineImage.Spec.OwnerID == "" {
+	nodeStatusDown := false
+	if engineImage.Spec.OwnerID != "" {
+		nodeStatusDown, err = ic.ds.IsNodeDownOrDeleted(engineImage.Spec.OwnerID)
+		if err != nil {
+			logrus.Warnf("Found error while checking ownerID is down or deleted:%v", err)
+		}
+	}
+
+	if engineImage.Spec.OwnerID == "" || nodeStatusDown {
 		// Claim it
 		engineImage.Spec.OwnerID = ic.controllerID
 		engineImage, err = ic.ds.UpdateEngineImage(engineImage)


### PR DESCRIPTION
The engine spec owner ID is not updated when the node that is referred by the current ownerID goes down. Controllers running in other nodes wouldn't pick up as the ownerID value is not empty.
Hence the following code changes explicitly check if the node is down and then set owner ID to the current controller ID.
