### PR TITLE
Allow node removal upon role change from worker to master

### DIFF
--- a/controller/kubernetes_controller_test.go
+++ b/controller/kubernetes_controller_test.go
@@ -558,7 +558,7 @@ func (s *TestSuite) TestDisasterRecovery(c *C) {
 	tc = generateDisasterRecoveryTestCaseTemplate()
 	tc.volume.Status.State = types.VolumeStateDetached
 	tc.pvc.Status.Phase = apiv1.ClaimBound
-	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeDown)
+	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeGone)
 	workloads = []types.WorkloadStatus{}
 	for _, p := range tc.pods {
 		p.Status.Phase = apiv1.PodPending
@@ -610,7 +610,7 @@ func (s *TestSuite) TestDisasterRecovery(c *C) {
 	tc = generateDisasterRecoveryTestCaseTemplate()
 	tc.volume.Status.State = types.VolumeStateDetached
 	tc.pvc.Status.Phase = apiv1.ClaimBound
-	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeDown)
+	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeGone)
 	workloads = []types.WorkloadStatus{}
 	for _, p := range tc.pods {
 		p.DeletionTimestamp = &deleteTime
@@ -644,7 +644,7 @@ func (s *TestSuite) TestDisasterRecovery(c *C) {
 	tc = generateDisasterRecoveryTestCaseTemplate()
 	tc.volume.Status.State = types.VolumeStateDetached
 	tc.pvc.Status.Phase = apiv1.ClaimBound
-	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeDown)
+	tc.node = newNode(TestNode1, TestNamespace, true, types.ConditionStatusFalse, types.NodeConditionReasonKubernetesNodeGone)
 	workloads = []types.WorkloadStatus{}
 	tc.pods = append(tc.pods, newPodWithPVC(TestPod2))
 	for _, p := range tc.pods {

--- a/controller/node_controller.go
+++ b/controller/node_controller.go
@@ -391,10 +391,10 @@ func (nc *NodeController) syncNode(key string) (err error) {
 			condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
 			if condition.Status != types.ConditionStatusFalse {
 				condition.LastTransitionTime = util.Now()
-				nc.eventRecorder.Eventf(node, v1.EventTypeWarning, types.NodeConditionReasonKubernetesNodeDown, "Kubernetes node missing: node %v has been removed from the cluster and there is no manager pod running on it", node.Name)
+				nc.eventRecorder.Eventf(node, v1.EventTypeWarning, types.NodeConditionReasonKubernetesNodeGone, "Kubernetes node missing: node %v has been removed from the cluster and there is no manager pod running on it", node.Name)
 			}
 			condition.Status = types.ConditionStatusFalse
-			condition.Reason = string(types.NodeConditionReasonKubernetesNodeDown)
+			condition.Reason = string(types.NodeConditionReasonKubernetesNodeGone)
 			condition.Message = fmt.Sprintf("Kubernetes node missing: node %v has been removed from the cluster and there is no manager pod running on it", node.Name)
 			node.Status.Conditions[types.NodeConditionTypeReady] = condition
 			// set node unschedulable

--- a/controller/volume_controller_test.go
+++ b/controller/volume_controller_test.go
@@ -288,7 +288,7 @@ func (s *TestSuite) TestVolumeLifeCycle(c *C) {
 	// volume attaching, start replicas, one node down
 	tc = generateVolumeTestCaseTemplate()
 	tc.volume.Spec.NodeID = TestNode1
-	tc.nodes[1] = newNode(TestNode2, TestNamespace, false, types.ConditionStatusFalse, string(types.NodeConditionReasonKubernetesNodeDown))
+	tc.nodes[1] = newNode(TestNode2, TestNamespace, false, types.ConditionStatusFalse, string(types.NodeConditionReasonKubernetesNodeGone))
 	tc.copyCurrentToExpect()
 	tc.expectVolume.Status.State = types.VolumeStateAttaching
 	tc.expectVolume.Status.CurrentImage = tc.volume.Spec.EngineImage

--- a/datastore/longhorn.go
+++ b/datastore/longhorn.go
@@ -952,7 +952,7 @@ func (s *DataStore) IsNodeDownOrDeleted(name string) (bool, error) {
 	}
 	cond := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
 	if cond.Status == types.ConditionStatusFalse &&
-		(cond.Reason == string(types.NodeConditionReasonKubernetesNodeDown) ||
+		(cond.Reason == string(types.NodeConditionReasonKubernetesNodeGone) ||
 			cond.Reason == string(types.NodeConditionReasonKubernetesNodeNotReady)) {
 		return true, nil
 	}

--- a/manager/node.go
+++ b/manager/node.go
@@ -128,7 +128,7 @@ func (m *VolumeManager) DeleteNode(name string) error {
 	}
 	condition := types.GetNodeConditionFromStatus(node.Status, types.NodeConditionTypeReady)
 	// Only could delete node from longhorn if kubernetes node missing
-	if condition.Status == types.ConditionStatusTrue || condition.Reason != types.NodeConditionReasonKubernetesNodeDown ||
+	if condition.Status == types.ConditionStatusTrue || condition.Reason != types.NodeConditionReasonKubernetesNodeGone ||
 		node.Spec.AllowScheduling || len(replicas) > 0 || len(engines) > 0 {
 		return fmt.Errorf("Could not delete node %v with node ready condition is %v, reason is %v, node schedulable %v, and %v replica, %v engine running on it", name,
 			condition.Status, condition.Reason, node.Spec.AllowScheduling, len(replicas), len(engines))

--- a/types/resource.go
+++ b/types/resource.go
@@ -231,7 +231,7 @@ const (
 const (
 	NodeConditionReasonManagerPodDown            = "ManagerPodDown"
 	NodeConditionReasonManagerPodMissing         = "ManagerPodMissing"
-	NodeConditionReasonKubernetesNodeDown        = "KubernetesNodeDown"
+	NodeConditionReasonKubernetesNodeGone        = "KubernetesNodeGone"
 	NodeConditionReasonKubernetesNodeNotReady    = "KubernetesNodeNotReady"
 	NodeConditionReasonKubernetesNodePressure    = "KubernetesNodePressure"
 	NodeConditionReasonUnknownNodeConditionTrue  = "UnknownNodeConditionTrue"


### PR DESCRIPTION
When the role of the node changes from worker to non-worker, the manager pod will be stopped and as a result node removal was resulting in failure. The following code changes support removing node in such situations.

IssueURL: https://github.com/rancher/longhorn/issues/453