### PR TITLE
Support bundle not deleting the directory

### DIFF
--- a/manager/misc.go
+++ b/manager/misc.go
@@ -61,6 +61,7 @@ func (m *VolumeManager) GetSupportBundle(name string) (*SupportBundle, error) {
 
 func (m *VolumeManager) DeleteSupportBundle() {
 	os.Remove(filepath.Join("/tmp", m.sb.Filename))
+	os.RemoveAll(filepath.Join("/tmp", m.sb.Name))
 	m.sb = nil
 }
 


### PR DESCRIPTION
When the object expires, the support bundle file was getting deleted but not the directory. The following code changes delete the directory as well