### PR TITLE
Configure drone to publish to dockerhub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,26 @@ steps:
   - name: socket
     path: /var/run/docker.sock
 
+- name: docker-publish-master
+  pull: default
+  image: plugins/docker
+  settings:
+    context: package/
+    custom_dns: 1.1.1.1
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: rancher/longhorn-manager
+    tag: master
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - master
+    event:
+    - push
+
+
 volumes:
 - name: socket
   host:


### PR DESCRIPTION
  - Publish Longhorn manager image to dockerhub when push event happens to master branch
  - image will be published with tag (master)